### PR TITLE
Add export files for build and install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,9 +87,11 @@ option(GEMM_VECTORIZATION_SUPPORT "Whether to enable vectorization in Gemm kerne
 add_definitions(-DCL_TARGET_OPENCL_VERSION=220)
 
 set(CBLAS_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/external/cblas/include)
-set(COMPUTECPP_SDK_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/external/computecpp-sdk/include)
+set(COMPUTECPP_SDK_INCLUDE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/computecpp-sdk/include>
+  $<INSTALL_INTERFACE:include>)
 set(SYCLBLAS_GENERATED_SRC ${CMAKE_CURRENT_BINARY_DIR}/generated_src)
-set(SYCLBLAS_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set(SYCLBLAS_INCLUDE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
 set(SYCLBLAS_COMMON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/common/include)
 set(SYCLBLAS_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(SYCLBLAS_SRC_GENERATOR ${CMAKE_CURRENT_SOURCE_DIR}/python_generator)
@@ -129,47 +131,59 @@ if (WIN32)
   endif()
 endif()
 if(is_computecpp)
-  set_target_properties(sycl_blas PROPERTIES
-    VERSION ${PROJECT_VERSION}
-    INTERFACE_LINK_LIBRARIES ComputeCpp::ComputeCpp
-    INTERFACE_INCLUDE_DIRECTORIES "${SYCLBLAS_INCLUDE};${COMPUTECPP_SDK_INCLUDE};${SYCL_INCLUDE_DIRS}"
-  )
+  set(sycl_impl ComputeCpp::ComputeCpp)
 elseif(is_dpcpp)
-  set_target_properties(sycl_blas PROPERTIES
-    VERSION ${PROJECT_VERSION}
-    INTERFACE_LINK_LIBRARIES DPCPP::DPCPP
-    INTERFACE_INCLUDE_DIRECTORIES "${SYCLBLAS_INCLUDE};${COMPUTECPP_SDK_INCLUDE};${SYCL_INCLUDE_DIRS}"
-  )
+  set(sycl_impl DPCPP::DPCPP)
   add_sycl_to_target(TARGET sycl_blas SOURCES)
 elseif(is_hipsycl)
-  set_target_properties(sycl_blas PROPERTIES
-    VERSION ${PROJECT_VERSION}
-    INTERFACE_LINK_LIBRARIES hipSYCL::hipSYCL-rt
-    INTERFACE_INCLUDE_DIRECTORIES "${SYCLBLAS_INCLUDE};${COMPUTECPP_SDK_INCLUDE};${SYCL_INCLUDE_DIRS}"
-  )
+  set(sycl_impl hipSYCL::hipSYCL-rt)
   add_sycl_to_target(TARGET sycl_blas SOURCES)
 endif()
+set_target_properties(sycl_blas PROPERTIES
+  VERSION ${PROJECT_VERSION}
+  INTERFACE_LINK_LIBRARIES ${sycl_impl}
+  INTERFACE_INCLUDE_DIRECTORIES "${SYCLBLAS_INCLUDE};${COMPUTECPP_SDK_INCLUDE};${SYCL_INCLUDE_DIRS}"
+)
 
 if(IMGDNN_DIR)
   target_link_libraries(sycl_blas PUBLIC IMGDNN::IMGDNN)
 endif()
 
+include(CMakePackageConfigHelpers)
+set(version_file "${CMAKE_CURRENT_BINARY_DIR}/cmake/sycl_blas-version.cmake")
+write_basic_package_version_file(${version_file}
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion
+)
+
 include(GNUInstallDirs)
 install(TARGETS sycl_blas
-  RUNTIME
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
-    COMPONENT sycl_blas
-  LIBRARY
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT sycl_blas
-  ARCHIVE
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT sycl_blas
+  EXPORT sycl_blas
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-install(DIRECTORY ${SYCLBLAS_INCLUDE}/
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sycl_blas"
+
+install(DIRECTORY ${SYCLBLAS_INCLUDE}
+  DESTINATION ${CMAKE_INSTALL_PREFIX}
   COMPONENT sycl_blas
   FILES_MATCHING PATTERN "*.h"
+)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/external/computecpp-sdk/include/vptr
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  COMPONENT sycl_blas
+)
+set(cmake_config_dest "lib/sycl_blas/cmake")
+install(FILES ${version_file} DESTINATION ${cmake_config_dest})
+install(EXPORT sycl_blas
+  DESTINATION ${cmake_config_dest}
+  NAMESPACE SYCL_BLAS::
+  FILE sycl_blas-config.cmake
+)
+
+export(EXPORT sycl_blas
+  NAMESPACE SYCL_BLAS::
+  FILE sycl_blas-config.cmake
 )
 
 option(BLAS_ENABLE_TESTING "Whether to enable testing" ON)


### PR DESCRIPTION
CMake supports having export files which describe the library to
users seeking it in either the build tree or an installed directory.
This means users can now specify `-Dsycl_blas_DIR=$install_path`
during configuration and CMake will be able to locate the library
and headers.