### PR TITLE
Refactor level1 asum operator

### DIFF
--- a/benchmark/portblas/blas1/asum.cpp
+++ b/benchmark/portblas/blas1/asum.cpp
@@ -63,8 +63,9 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
   scalar_t vr_temp = 0;
   {
     auto vr_temp_gpu = blas::helper::allocate<mem_alloc, scalar_t>(1, q);
-    auto asum_event =
-        _asum(sb_handle, size, inx, static_cast<index_t>(1), vr_temp_gpu);
+    auto copy_temp =
+        blas::helper::copy_to_device<scalar_t>(q, &vr_temp, vr_temp_gpu, 1);
+    auto asum_event = _asum(sb_handle, size, inx, static_cast<index_t>(1), vr_temp_gpu);
     sb_handle.wait(asum_event);
     auto copy_output = blas::helper::copy_to_host(q, vr_temp_gpu, &vr_temp, 1);
     sb_handle.wait(copy_output);

--- a/include/interface/blas1_interface.h
+++ b/include/interface/blas1_interface.h
@@ -131,6 +131,19 @@ template <typename sb_handle_t, typename container_0_t, typename container_1_t,
 typename sb_handle_t::event_t _asum(
     sb_handle_t &sb_handle, index_t _N, container_0_t _vx, increment_t _incx,
     container_1_t _rs, const typename sb_handle_t::event_t &_dependencies);
+
+
+/*!
+ * \brief Prototype for the internal implementation of the ASUM operation. See
+ * documentation in the blas1_interface.hpp file for details.
+ */
+template <int localSize, int localMemSize, typename sb_handle_t,
+          typename container_0_t, typename container_1_t, typename index_t,
+          typename increment_t>
+typename sb_handle_t::event_t _asum_impl(sb_handle_t &sb_handle, index_t _N,
+                                         container_0_t _vx, increment_t _incx,
+                                         container_1_t _rs, int blocks);
+
 /**
  * \brief IAMAX finds the index of the first element having maximum
  * @param _vx BufferIterator or USM pointer

--- a/include/interface/blas1_interface.h
+++ b/include/interface/blas1_interface.h
@@ -132,7 +132,6 @@ typename sb_handle_t::event_t _asum(
     sb_handle_t &sb_handle, index_t _N, container_0_t _vx, increment_t _incx,
     container_1_t _rs, const typename sb_handle_t::event_t &_dependencies);
 
-
 /*!
  * \brief Prototype for the internal implementation of the ASUM operation. See
  * documentation in the blas1_interface.hpp file for details.
@@ -140,9 +139,10 @@ typename sb_handle_t::event_t _asum(
 template <int localSize, int localMemSize, typename sb_handle_t,
           typename container_0_t, typename container_1_t, typename index_t,
           typename increment_t>
-typename sb_handle_t::event_t _asum_impl(sb_handle_t &sb_handle, index_t _N,
-                                         container_0_t _vx, increment_t _incx,
-                                         container_1_t _rs, int blocks);
+typename sb_handle_t::event_t _asum_impl(
+    sb_handle_t &sb_handle, index_t _N, container_0_t _vx, increment_t _incx,
+    container_1_t _rs, const index_t number_WG,
+    const typename sb_handle_t::event_t &_dependencies);
 
 /**
  * \brief IAMAX finds the index of the first element having maximum

--- a/include/operations/blas1_trees.h
+++ b/include/operations/blas1_trees.h
@@ -182,6 +182,29 @@ struct AssignReduction {
   void adjust_access_displacement();
 };
 
+/*! .
+ * @brief Implements the ASUM operator providing different
+ * implementations of the ASUM kernel function.
+ *
+ * The class is constructed using the make_asum function below.
+ *
+ */
+template <typename lhs_t, typename rhs_t>
+struct Asum {
+  using value_t = typename lhs_t::value_t;
+  using index_t = typename rhs_t::index_t;
+  lhs_t lhs_;
+  rhs_t rhs_;
+  Asum(lhs_t &_l, rhs_t &_r);
+  index_t get_size() const;
+  bool valid_thread(cl::sycl::nd_item<1> ndItem) const;
+  value_t eval(cl::sycl::nd_item<1> ndItem);
+  template <typename sharedT>
+  value_t eval(sharedT scratch, cl::sycl::nd_item<1> ndItem);
+  void bind(cl::sycl::handler &h);
+  void adjust_access_displacement();
+};
+
 /*! Rotg.
  * @brief Implements the rotg (blas level 1 api)
  */
@@ -230,6 +253,11 @@ inline AssignReduction<operator_t, lhs_t, rhs_t> make_assign_reduction(
     index_t global_num_thread_) {
   return AssignReduction<operator_t, lhs_t, rhs_t>(
       lhs_, rhs_, local_num_thread_, global_num_thread_);
+}
+
+template <typename lhs_t, typename rhs_t>
+inline Asum<lhs_t, rhs_t> make_asum(lhs_t &lhs_, rhs_t &rhs_) {
+  return Asum<lhs_t, rhs_t>(lhs_, rhs_);
 }
 
 /*!

--- a/include/operations/blas1_trees.h
+++ b/include/operations/blas1_trees.h
@@ -183,19 +183,20 @@ struct AssignReduction {
 };
 
 /*! .
- * @brief Implements the ASUM operator providing different
- * implementations of the ASUM kernel function.
+ * @brief Generic implementation for operators that require a
+ * reduction inside kernel code. (i.e. asum)
  *
- * The class is constructed using the make_asum function below.
+ * The class is constructed using the make_wg_atomic_reduction
+ * function below.
  *
  */
-template <typename lhs_t, typename rhs_t>
-struct Asum {
+template <typename operator_t, typename lhs_t, typename rhs_t>
+struct WGAtomicReduction {
   using value_t = typename lhs_t::value_t;
   using index_t = typename rhs_t::index_t;
   lhs_t lhs_;
   rhs_t rhs_;
-  Asum(lhs_t &_l, rhs_t &_r);
+  WGAtomicReduction(lhs_t &_l, rhs_t &_r);
   index_t get_size() const;
   bool valid_thread(cl::sycl::nd_item<1> ndItem) const;
   value_t eval(cl::sycl::nd_item<1> ndItem);
@@ -255,9 +256,10 @@ inline AssignReduction<operator_t, lhs_t, rhs_t> make_assign_reduction(
       lhs_, rhs_, local_num_thread_, global_num_thread_);
 }
 
-template <typename lhs_t, typename rhs_t>
-inline Asum<lhs_t, rhs_t> make_asum(lhs_t &lhs_, rhs_t &rhs_) {
-  return Asum<lhs_t, rhs_t>(lhs_, rhs_);
+template <typename operator_t, typename lhs_t, typename rhs_t>
+inline WGAtomicReduction<operator_t, lhs_t, rhs_t> make_wg_atomic_reduction(
+    lhs_t &lhs_, rhs_t &rhs_) {
+  return WGAtomicReduction<operator_t, lhs_t, rhs_t>(lhs_, rhs_);
 }
 
 /*!

--- a/src/interface/blas1/backend/amd_gpu.hpp
+++ b/src/interface/blas1/backend/amd_gpu.hpp
@@ -1,0 +1,54 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  portBLAS: BLAS implementation using SYCL
+ *
+ *  @filename amd_gpu.hpp
+ *
+ **************************************************************************/
+#ifndef PORTBLAS_ASUM_AMD_GPU_BACKEND_HPP
+#define PORTBLAS_ASUM_AMD_GPU_BACKEND_HPP
+#include "interface/blas1_interface.h"
+
+namespace blas {
+namespace asum {
+namespace backend {
+template <typename sb_handle_t, typename container_0_t, typename container_1_t,
+          typename index_t, typename increment_t>
+typename sb_handle_t::event_t _asum(sb_handle_t &sb_handle, index_t _N,
+                                    container_0_t _vx, increment_t _incx,
+                                    container_1_t _rs) {
+  if (_N < (1 << 18)) {
+    constexpr auto localSize = 1024ul;
+    const auto blocks = (_N + localSize - 1) / localSize;
+    return blas::internal::_asum_impl<localSize, 32>(sb_handle, _N, _vx, _incx,
+                                                     _rs, blocks);
+  } else {
+    constexpr auto localSize = 512ul;
+    constexpr auto blocks = 256ul;
+    return blas::internal::_asum_impl<localSize, 32>(sb_handle, _N, _vx, _incx,
+                                                     _rs, blocks);
+  }
+}
+}  // namespace backend
+}  // namespace asum
+
+}  // namespace blas
+
+#endif

--- a/src/interface/blas1/backend/amd_gpu.hpp
+++ b/src/interface/blas1/backend/amd_gpu.hpp
@@ -31,19 +31,19 @@ namespace asum {
 namespace backend {
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
           typename index_t, typename increment_t>
-typename sb_handle_t::event_t _asum(sb_handle_t &sb_handle, index_t _N,
-                                    container_0_t _vx, increment_t _incx,
-                                    container_1_t _rs) {
+typename sb_handle_t::event_t _asum(
+    sb_handle_t& sb_handle, index_t _N, container_0_t _vx, increment_t _incx,
+    container_1_t _rs, const typename sb_handle_t::event_t& _dependencies) {
   if (_N < (1 << 18)) {
-    constexpr auto localSize = 1024ul;
-    const auto blocks = (_N + localSize - 1) / localSize;
-    return blas::internal::_asum_impl<localSize, 32>(sb_handle, _N, _vx, _incx,
-                                                     _rs, blocks);
+    constexpr index_t localSize = 1024;
+    const index_t number_WG = (_N + localSize - 1) / localSize;
+    return blas::internal::_asum_impl<static_cast<int>(localSize), 32>(
+        sb_handle, _N, _vx, _incx, _rs, number_WG, _dependencies);
   } else {
-    constexpr auto localSize = 512ul;
-    constexpr auto blocks = 256ul;
-    return blas::internal::_asum_impl<localSize, 32>(sb_handle, _N, _vx, _incx,
-                                                     _rs, blocks);
+    constexpr int localSize = 512;
+    constexpr index_t number_WG = 256;
+    return blas::internal::_asum_impl<localSize, 32>(
+        sb_handle, _N, _vx, _incx, _rs, number_WG, _dependencies);
   }
 }
 }  // namespace backend

--- a/src/interface/blas1/backend/backend.hpp
+++ b/src/interface/blas1/backend/backend.hpp
@@ -1,0 +1,34 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  portBLAS: BLAS implementation using SYCL
+ *
+ *  @filename backend.hpp
+ *
+ **************************************************************************/
+#ifdef INTEL_GPU
+#include "interface/blas1/backend/intel_gpu.hpp"
+#elif AMD_GPU
+#include "interface/blas1/backend/amd_gpu.hpp"
+#elif NVIDIA_GPU
+#include "interface/blas1/backend/nvidia_gpu.hpp"
+#else
+#include "interface/blas1/backend/default_cpu.hpp"
+#endif
+

--- a/src/interface/blas1/backend/default_cpu.hpp
+++ b/src/interface/blas1/backend/default_cpu.hpp
@@ -1,0 +1,47 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  portBLAS: BLAS implementation using SYCL
+ *
+ *  @filename defaul_cpu.hpp
+ *
+ **************************************************************************/
+#ifndef PORTBLAS_ASUM_DEFAULT_CPU_BACKEND_HPP
+#define PORTBLAS_ASUM_DEFAULT_CPU_BACKEND_HPP
+#include "interface/blas1_interface.h"
+
+namespace blas {
+namespace asum {
+namespace backend {
+template <typename sb_handle_t, typename container_0_t, typename container_1_t,
+          typename index_t, typename increment_t>
+typename sb_handle_t::event_t _asum(sb_handle_t &sb_handle, index_t _N,
+                                    container_0_t _vx, increment_t _incx,
+                                    container_1_t _rs) {
+  const auto localSize = 4;
+  const auto blocks = 16;
+  return blas::internal::_asum_impl<localSize, 0>(sb_handle, _N, _vx, _incx,
+                                                  _rs, blocks);
+}
+}  // namespace backend
+}  // namespace asum
+
+}  // namespace blas
+
+#endif

--- a/src/interface/blas1/backend/default_cpu.hpp
+++ b/src/interface/blas1/backend/default_cpu.hpp
@@ -31,13 +31,13 @@ namespace asum {
 namespace backend {
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
           typename index_t, typename increment_t>
-typename sb_handle_t::event_t _asum(sb_handle_t &sb_handle, index_t _N,
-                                    container_0_t _vx, increment_t _incx,
-                                    container_1_t _rs) {
-  const auto localSize = 4;
-  const auto blocks = 16;
-  return blas::internal::_asum_impl<localSize, 0>(sb_handle, _N, _vx, _incx,
-                                                  _rs, blocks);
+typename sb_handle_t::event_t _asum(
+    sb_handle_t& sb_handle, index_t _N, container_0_t _vx, increment_t _incx,
+    container_1_t _rs, const typename sb_handle_t::event_t& _dependencies) {
+  constexpr int localSize = 8;
+  constexpr index_t number_WG = 16;
+  return blas::internal::_asum_impl<localSize, 0>(
+      sb_handle, _N, _vx, _incx, _rs, number_WG, _dependencies);
 }
 }  // namespace backend
 }  // namespace asum

--- a/src/interface/blas1/backend/intel_gpu.hpp
+++ b/src/interface/blas1/backend/intel_gpu.hpp
@@ -1,0 +1,47 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  portBLAS: BLAS implementation using SYCL
+ *
+ *  @filename intel_gpu.hpp
+ *
+ **************************************************************************/
+#ifndef PORTBLAS_ASUM_INTEL_GPU_BACKEND_HPP
+#define PORTBLAS_ASUM_INTEL_GPU_BACKEND_HPP
+#include "interface/blas1_interface.h"
+
+namespace blas {
+namespace asum {
+namespace backend {
+template <typename sb_handle_t, typename container_0_t, typename container_1_t,
+          typename index_t, typename increment_t>
+typename sb_handle_t::event_t _asum(sb_handle_t &sb_handle, index_t _N,
+                                    container_0_t _vx, increment_t _incx,
+                                    container_1_t _rs) {
+  constexpr auto localSize = 128;
+  const auto blocks = std::min((_N + localSize - 1) / localSize, 512);
+  return blas::internal::_asum_impl<localSize,16>(sb_handle, _N, _vx,
+                                                           _incx, _rs, blocks);
+}
+}  // namespace backend
+}  // namespace asum
+
+}  // namespace blas
+
+#endif

--- a/src/interface/blas1/backend/intel_gpu.hpp
+++ b/src/interface/blas1/backend/intel_gpu.hpp
@@ -31,13 +31,14 @@ namespace asum {
 namespace backend {
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
           typename index_t, typename increment_t>
-typename sb_handle_t::event_t _asum(sb_handle_t &sb_handle, index_t _N,
-                                    container_0_t _vx, increment_t _incx,
-                                    container_1_t _rs) {
-  constexpr auto localSize = 128;
-  const auto blocks = std::min((_N + localSize - 1) / localSize, 512);
-  return blas::internal::_asum_impl<localSize,16>(sb_handle, _N, _vx,
-                                                           _incx, _rs, blocks);
+typename sb_handle_t::event_t _asum(
+    sb_handle_t& sb_handle, index_t _N, container_0_t _vx, increment_t _incx,
+    container_1_t _rs, const typename sb_handle_t::event_t& _dependencies) {
+  constexpr index_t localSize = 128;
+  const index_t number_WG =
+      std::min((_N + localSize - 1) / localSize, static_cast<index_t>(512));
+  return blas::internal::_asum_impl<static_cast<int>(localSize), 32>(
+      sb_handle, _N, _vx, _incx, _rs, number_WG, _dependencies);
 }
 }  // namespace backend
 }  // namespace asum

--- a/src/interface/blas1/backend/nvidia_gpu.hpp
+++ b/src/interface/blas1/backend/nvidia_gpu.hpp
@@ -1,0 +1,55 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  portBLAS: BLAS implementation using SYCL
+ *
+ *  @filename nvidia_gpu.hpp
+ *
+ **************************************************************************/
+#ifndef PORTBLAS_ASUM_NVIDIA_GPU_BACKEND_HPP
+#define PORTBLAS_ASUM_NVIDIA_GPU_BACKEND_HPP
+#include "interface/blas1_interface.h"
+
+namespace blas {
+namespace asum {
+namespace backend {
+template <typename sb_handle_t, typename container_0_t, typename container_1_t,
+          typename index_t, typename increment_t>
+typename sb_handle_t::event_t _asum(sb_handle_t &sb_handle, index_t _N,
+                                    container_0_t _vx, increment_t _incx,
+                                    container_1_t _rs) {
+  if (_N < (1 << 23)) {
+    constexpr auto localSize = 512;  // sb_handle.get_work_group_size();
+    const auto blocks =
+        (_N < (1 << 18)) ? (_N + localSize - 1) / localSize : 256;
+    return blas::internal::_asum_impl<localSize, 16>(sb_handle, _N, _vx, _incx,
+                                                     _rs, blocks);
+  } else {
+    constexpr auto localSize = 512;  // sb_handle.get_work_group_size();
+    constexpr auto blocks = 1024;
+    return blas::internal::_asum_impl<localSize, 32>(sb_handle, _N, _vx, _incx,
+                                                     _rs, blocks);
+  }
+}
+}  // namespace backend
+}  // namespace asum
+
+}  // namespace blas
+
+#endif

--- a/src/interface/blas1/backend/nvidia_gpu.hpp
+++ b/src/interface/blas1/backend/nvidia_gpu.hpp
@@ -31,20 +31,21 @@ namespace asum {
 namespace backend {
 template <typename sb_handle_t, typename container_0_t, typename container_1_t,
           typename index_t, typename increment_t>
-typename sb_handle_t::event_t _asum(sb_handle_t &sb_handle, index_t _N,
-                                    container_0_t _vx, increment_t _incx,
-                                    container_1_t _rs) {
+typename sb_handle_t::event_t _asum(
+    sb_handle_t& sb_handle, index_t _N, container_0_t _vx, increment_t _incx,
+    container_1_t _rs, const typename sb_handle_t::event_t& _dependencies) {
   if (_N < (1 << 23)) {
-    constexpr auto localSize = 512;  // sb_handle.get_work_group_size();
-    const auto blocks =
-        (_N < (1 << 18)) ? (_N + localSize - 1) / localSize : 256;
-    return blas::internal::_asum_impl<localSize, 16>(sb_handle, _N, _vx, _incx,
-                                                     _rs, blocks);
+    constexpr index_t localSize = 512;
+    const index_t number_WG = (_N < (1 << 18))
+                                  ? (_N + localSize - 1) / localSize
+                                  : static_cast<index_t>(256);
+    return blas::internal::_asum_impl<static_cast<index_t>(localSize), 32>(
+        sb_handle, _N, _vx, _incx, _rs, number_WG, _dependencies);
   } else {
-    constexpr auto localSize = 512;  // sb_handle.get_work_group_size();
-    constexpr auto blocks = 1024;
-    return blas::internal::_asum_impl<localSize, 32>(sb_handle, _N, _vx, _incx,
-                                                     _rs, blocks);
+    constexpr int localSize = 512;
+    constexpr index_t number_WG = 1024;
+    return blas::internal::_asum_impl<localSize, 32>(
+        sb_handle, _N, _vx, _incx, _rs, number_WG, _dependencies);
   }
 }
 }  // namespace backend

--- a/src/interface/blas1_interface.hpp
+++ b/src/interface/blas1_interface.hpp
@@ -236,7 +236,6 @@ typename sb_handle_t::event_t _asum_impl(
     const typename sb_handle_t::event_t &_dependencies) {
   typename VectorViewType<container_0_t, index_t, increment_t>::type vx =
       make_vector_view(_vx, _incx, _N);
-  static const typename ValueType<container_1_t>::type init_res{0};
   auto rs = make_vector_view(_rs, static_cast<increment_t>(1),
                              static_cast<index_t>(1));
   typename sb_handle_t::event_t ret;

--- a/src/interface/blas1_interface.hpp
+++ b/src/interface/blas1_interface.hpp
@@ -27,12 +27,12 @@
 #define PORTBLAS_BLAS1_INTERFACE_HPP
 
 #include <cmath>
-#include <iostream>
 #include <stdexcept>
 #include <vector>
 
 #include "blas_meta.h"
 #include "container/sycl_iterator.h"
+#include "interface/blas1/backend/backend.hpp"
 #include "interface/blas1_interface.h"
 #include "operations/blas1_trees.h"
 #include "operations/blas_constants.h"
@@ -190,6 +190,8 @@ template <typename sb_handle_t, typename container_0_t, typename container_1_t,
 typename sb_handle_t::event_t _asum(
     sb_handle_t &sb_handle, index_t _N, container_0_t _vx, increment_t _incx,
     container_1_t _rs, const typename sb_handle_t::event_t &_dependencies) {
+  // keep compatibility with older sycl versions
+#if SYCL_LANGUAGE_VERSION < 202000
   typename VectorViewType<container_0_t, index_t, increment_t>::type vx =
       make_vector_view(_vx, _incx, _N);
   auto rs = make_vector_view(_rs, static_cast<increment_t>(1),
@@ -201,7 +203,49 @@ typename sb_handle_t::event_t _asum(
                                                              localSize * nWG);
   auto ret = sb_handle.execute(assignOp, _dependencies);
   return ret;
+#else
+  return blas::asum::backend::_asum(sb_handle, _N, _vx, _incx, _rs);
+#endif
 }
+
+#if SYCL_LANGUAGE_VERSION >= 202000
+/*! _asum_impl.
+ * @brief Internal implementation of the Absolute sum operator.
+ *
+ * This function contains the code that sets up and executes the kernels
+ * required to perform the asum operation.
+ *
+ * This function is called by blas::internal::backend::asum which, dependent on
+ * the platform being compiled for and other parameters, provides different
+ * template parameters to ensure the most optimal kernel is constructed.
+ *
+ * @tparam localSize  specifies the number of threads per work group used by
+ *                    the kernel
+ * @tparam localMemSize specifies the size of local shared memory to use, which
+ *                      is device and implementation dependent. If 0 the
+ *                      implementation use a kernel implementation which doesn't
+ *                      require local memory.
+ */
+template <int localSize, int localMemSize, typename sb_handle_t,
+          typename container_0_t, typename container_1_t, typename index_t,
+          typename increment_t>
+typename sb_handle_t::event_t _asum_impl(sb_handle_t &sb_handle, index_t _N,
+                                         container_0_t _vx, increment_t _incx,
+                                         container_1_t _rs, int blocks) {
+  auto vx = make_vector_view(_vx, _incx, _N);
+  auto rs = make_vector_view(_rs, static_cast<increment_t>(1),
+                             static_cast<index_t>(1));
+  typename sb_handle_t::event_t ret;
+  auto asumOp = make_asum(rs, vx);
+  if constexpr (localMemSize != 0) {
+    ret =
+        sb_handle.execute(asumOp, localSize, blocks * localSize, localMemSize);
+  } else {
+    ret = sb_handle.execute(asumOp, localSize, blocks * localSize);
+  }
+  return ret;
+}
+#endif
 
 /**
  * \brief IAMAX finds the index of the first element having maximum

--- a/src/operations/blas1/asum.hpp
+++ b/src/operations/blas1/asum.hpp
@@ -1,0 +1,135 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  portBLAS: BLAS implementation using SYCL
+ *
+ *  @filename asum.hpp
+ *
+ **************************************************************************/
+
+#ifndef ASUM_HPP
+#define ASUM_HPP
+#include "operations/blas1_trees.h"
+#include "operations/blas_operators.hpp"
+#include "views/view_sycl.hpp"
+
+namespace blas {
+
+/*! Asum.
+ * @brief Implements the reduction operation for assignments
+ * (in the form y = x) with y a scalar and x a subexpression tree.
+ */
+template <typename lhs_t, typename rhs_t>
+Asum<lhs_t, rhs_t>::Asum(lhs_t &_l, rhs_t &_r) : lhs_(_l), rhs_(_r){};
+
+template <typename lhs_t, typename rhs_t>
+PORTBLAS_INLINE typename Asum<lhs_t, rhs_t>::index_t
+Asum<lhs_t, rhs_t>::get_size() const {
+  return rhs_.get_size();
+}
+
+template <typename lhs_t, typename rhs_t>
+PORTBLAS_INLINE bool Asum<lhs_t, rhs_t>::valid_thread(
+    cl::sycl::nd_item<1> ndItem) const {
+  return true;
+}
+
+template <typename lhs_t, typename rhs_t>
+PORTBLAS_INLINE typename Asum<lhs_t, rhs_t>::value_t Asum<lhs_t, rhs_t>::eval(
+    cl::sycl::nd_item<1> ndItem) {
+  auto atomic_res = sycl::atomic_ref<value_t, sycl::memory_order::relaxed,
+                                     sycl::memory_scope::device,
+                                     sycl::access::address_space::global_space>(
+      lhs_.get_data()[0]);
+  const auto size = rhs_.get_size();
+  int lid = ndItem.get_global_linear_id();
+  value_t in_val{0};
+
+  // First loop for big arrays
+  for (int id = lid; id < size;
+       id += ndItem.get_local_range()[0] * ndItem.get_group_range()[0]) {
+    in_val += sycl::abs(rhs_.eval(id));
+  }
+
+  in_val =
+      sycl::reduce_over_group(ndItem.get_sub_group(), in_val, sycl::plus<>());
+
+  if ((ndItem.get_local_id() &
+       (ndItem.get_sub_group().get_local_range() - 1)) == 0) {
+    atomic_res += in_val;
+  }
+  return {};
+}
+template <typename lhs_t, typename rhs_t>
+template <typename sharedT>
+PORTBLAS_INLINE typename Asum<lhs_t, rhs_t>::value_t Asum<lhs_t, rhs_t>::eval(
+    sharedT scratch, cl::sycl::nd_item<1> ndItem) {
+  auto atomic_res = sycl::atomic_ref<value_t, sycl::memory_order::relaxed,
+                                     sycl::memory_scope::device,
+                                     sycl::access::address_space::global_space>(
+      lhs_.get_data()[0]);
+  const auto size = rhs_.get_size();
+  const int lid = static_cast<int>(ndItem.get_global_linear_id());
+  const auto loop_stride =
+      ndItem.get_local_range()[0] * ndItem.get_group_range()[0];
+  value_t in_val{0};
+
+  // First loop for big arrays
+  for (int id = lid; id < size; id += loop_stride) {
+    in_val += sycl::abs(rhs_.eval(id));
+  }
+
+  in_val =
+      sycl::reduce_over_group(ndItem.get_sub_group(), in_val, sycl::plus<>());
+
+  if (ndItem.get_sub_group().get_local_id() == 0) {
+    scratch[ndItem.get_sub_group().get_group_linear_id()] = in_val;
+  }
+  ndItem.barrier();
+
+  in_val =
+      (ndItem.get_local_id() < (ndItem.get_local_range()[0] /
+                                ndItem.get_sub_group().get_local_range()[0]))
+          ? scratch[ndItem.get_sub_group().get_local_id()]
+          : 0;
+  if (ndItem.get_sub_group().get_group_id() == 0) {
+    in_val =
+        sycl::reduce_over_group(ndItem.get_sub_group(), in_val, sycl::plus<>());
+  }
+  if (ndItem.get_local_id() == 0) {
+    atomic_res += in_val;
+  }
+
+  return {};
+}
+
+template <typename lhs_t, typename rhs_t>
+PORTBLAS_INLINE void Asum<lhs_t, rhs_t>::bind(cl::sycl::handler &h) {
+  lhs_.bind(h);
+  rhs_.bind(h);
+}
+
+template <typename lhs_t, typename rhs_t>
+PORTBLAS_INLINE void Asum<lhs_t, rhs_t>::adjust_access_displacement() {
+  lhs_.adjust_access_displacement();
+  rhs_.adjust_access_displacement();
+}
+}  // namespace blas
+
+#endif

--- a/src/operations/blas1_trees.hpp
+++ b/src/operations/blas1_trees.hpp
@@ -29,6 +29,9 @@
 #include "operations/blas1_trees.h"
 #include "operations/blas_operators.hpp"
 #include "views/view.hpp"
+#if SYCL_LANGUAGE_VERSION >= 202000
+#include "blas1/asum.hpp"
+#endif
 #include "views/view_sycl.hpp"
 #include <stdexcept>
 #include <vector>

--- a/src/operations/blas1_trees.hpp
+++ b/src/operations/blas1_trees.hpp
@@ -30,7 +30,7 @@
 #include "operations/blas_operators.hpp"
 #include "views/view.hpp"
 #if SYCL_LANGUAGE_VERSION >= 202000
-#include "blas1/asum.hpp"
+#include "blas1/WGAtomicReduction.hpp"
 #endif
 #include "views/view_sycl.hpp"
 #include <stdexcept>


### PR DESCRIPTION
This PR refactors the implementation of the `asum` operator.

It changes completely the kernel writing a specific one for this operator, thus it removes the usage of the `AssignReduction` and the new kernel performs the operations needed with a single launch.
Each architecture has its backend file that manages the different kernel sizes and its numbers are set empirically using available hardware.

For developing purpose, it also enables again the test for this operator for all compilers.