### PR TITLE
Fix building with different BLAS_INDEX_TYPES

### DIFF
--- a/benchmark/portblas/blas1/asum.cpp
+++ b/benchmark/portblas/blas1/asum.cpp
@@ -63,7 +63,8 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
   scalar_t vr_temp = 0;
   {
     auto vr_temp_gpu = blas::helper::allocate<mem_alloc, scalar_t>(1, q);
-    auto asum_event = _asum(sb_handle, size, inx, 1, vr_temp_gpu);
+    auto asum_event =
+        _asum(sb_handle, size, inx, static_cast<index_t>(1), vr_temp_gpu);
     sb_handle.wait(asum_event);
     auto copy_output = blas::helper::copy_to_host(q, vr_temp_gpu, &vr_temp, 1);
     sb_handle.wait(copy_output);
@@ -122,8 +123,8 @@ void register_benchmark(blas::SB_Handle* sb_handle_ptr, bool* success,
     };
 
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            size, mem_type).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size, mem_type)
+            .c_str(),
         BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }
@@ -135,7 +136,8 @@ void register_benchmark(blas_benchmark::Args& args,
   auto asum_params = blas_benchmark::utils::get_blas1_params(args);
 
   register_benchmark<scalar_t, blas::helper::AllocType::buffer>(
-      sb_handle_ptr, success, blas_benchmark::utils::MEM_TYPE_BUFFER, asum_params);
+      sb_handle_ptr, success, blas_benchmark::utils::MEM_TYPE_BUFFER,
+      asum_params);
 #ifdef SB_ENABLE_USM
   register_benchmark<scalar_t, blas::helper::AllocType::usm>(
       sb_handle_ptr, success, blas_benchmark::utils::MEM_TYPE_USM, asum_params);

--- a/benchmark/portblas/blas1/axpy.cpp
+++ b/benchmark/portblas/blas1/axpy.cpp
@@ -66,7 +66,9 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, index_t size,
     auto copy_temp = blas::helper::copy_to_device<scalar_t>(q, y_temp.data(),
                                                             y_temp_gpu, size);
     sb_handle.wait(copy_temp);
-    auto axpy_event = _axpy(sb_handle, size, alpha, inx, 1, y_temp_gpu, 1);
+    auto axpy_event =
+        _axpy(sb_handle, size, alpha, inx, static_cast<index_t>(1), y_temp_gpu,
+              static_cast<index_t>(1));
     sb_handle.wait(axpy_event);
     auto copy_output =
         blas::helper::copy_to_host(q, y_temp_gpu, y_temp.data(), size);
@@ -126,8 +128,8 @@ void register_benchmark(blas::SB_Handle* sb_handle_ptr, bool* success,
       run<scalar_t, mem_alloc>(st, sb_handle_ptr, size, success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            size, mem_type).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(size, mem_type)
+            .c_str(),
         BM_lambda, sb_handle_ptr, size, success)
         ->UseRealTime();
   }
@@ -139,7 +141,8 @@ void register_benchmark(blas_benchmark::Args& args,
   auto axpy_params = blas_benchmark::utils::get_blas1_params(args);
 
   register_benchmark<scalar_t, blas::helper::AllocType::buffer>(
-      sb_handle_ptr, success, blas_benchmark::utils::MEM_TYPE_BUFFER, axpy_params);
+      sb_handle_ptr, success, blas_benchmark::utils::MEM_TYPE_BUFFER,
+      axpy_params);
 #ifdef SB_ENABLE_USM
   register_benchmark<scalar_t, blas::helper::AllocType::usm>(
       sb_handle_ptr, success, blas_benchmark::utils::MEM_TYPE_USM, axpy_params);

--- a/benchmark/portblas/blas2/gbmv.cpp
+++ b/benchmark/portblas/blas2/gbmv.cpp
@@ -49,8 +49,8 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int ti,
   index_t incY = 1;
 
   blas_benchmark::utils::init_level_2_counters<
-      blas_benchmark::utils::Level2Op::gbmv, scalar_t>(state, t_str, beta, m, n,
-                                                       0, ku, kl);
+      blas_benchmark::utils::Level2Op::gbmv, scalar_t>(
+      state, t_str, beta, m, n, static_cast<index_t>(0), ku, kl);
 
   blas::SB_Handle& sb_handle = *sb_handle_ptr;
   auto q = sb_handle.get_queue();
@@ -156,8 +156,9 @@ void register_benchmark(blas::SB_Handle* sb_handle_ptr, bool* success,
                                success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            ts, m, n, kl, ku, mem_type).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(ts, m, n, kl,
+                                                                ku, mem_type)
+            .c_str(),
         BM_lambda, sb_handle_ptr, t, m, n, kl, ku, alpha, beta, success)
         ->UseRealTime();
   }
@@ -169,7 +170,8 @@ void register_benchmark(blas_benchmark::Args& args,
   auto gbmv_params = blas_benchmark::utils::get_gbmv_params<scalar_t>(args);
 
   register_benchmark<scalar_t, blas::helper::AllocType::buffer>(
-      sb_handle_ptr, success, blas_benchmark::utils::MEM_TYPE_BUFFER, gbmv_params);
+      sb_handle_ptr, success, blas_benchmark::utils::MEM_TYPE_BUFFER,
+      gbmv_params);
 #ifdef SB_ENABLE_USM
   register_benchmark<scalar_t, blas::helper::AllocType::usm>(
       sb_handle_ptr, success, blas_benchmark::utils::MEM_TYPE_USM, gbmv_params);

--- a/benchmark/portblas/blas3/gemm.cpp
+++ b/benchmark/portblas/blas3/gemm.cpp
@@ -49,7 +49,8 @@ void run(benchmark::State& state, blas::SB_Handle* sb_handle_ptr, int t1,
   index_t ldc = m;
 
   blas_benchmark::utils::init_level_3_counters<
-      blas_benchmark::utils::Level3Op::gemm, scalar_t>(state, beta, m, n, k, 1);
+      blas_benchmark::utils::Level3Op::gemm, scalar_t>(state, beta, m, n, k,
+                                                       static_cast<index_t>(1));
 
   blas::SB_Handle& sb_handle = *sb_handle_ptr;
   auto q = sb_handle.get_queue();
@@ -155,8 +156,9 @@ void register_benchmark(blas::SB_Handle* sb_handle_ptr, bool* success,
                                success);
     };
     benchmark::RegisterBenchmark(
-        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(
-            t1s, t2s, m, k, n, mem_type).c_str(),
+        blas_benchmark::utils::get_name<benchmark_op, scalar_t>(t1s, t2s, m, k,
+                                                                n, mem_type)
+            .c_str(),
         BM_lambda, sb_handle_ptr, t1, t2, m, k, n, alpha, beta, success)
         ->UseRealTime();
   }
@@ -167,7 +169,8 @@ void register_benchmark(blas_benchmark::Args& args,
                         blas::SB_Handle* sb_handle_ptr, bool* success) {
   auto gemm_params = blas_benchmark::utils::get_blas3_params<scalar_t>(args);
   register_benchmark<scalar_t, blas::helper::AllocType::buffer>(
-      sb_handle_ptr, success, blas_benchmark::utils::MEM_TYPE_BUFFER, gemm_params);
+      sb_handle_ptr, success, blas_benchmark::utils::MEM_TYPE_BUFFER,
+      gemm_params);
 #ifdef SB_ENABLE_USM
   register_benchmark<scalar_t, blas::helper::AllocType::usm>(
       sb_handle_ptr, success, blas_benchmark::utils::MEM_TYPE_USM, gemm_params);
@@ -175,8 +178,8 @@ void register_benchmark(blas_benchmark::Args& args,
 }
 
 namespace blas_benchmark {
-void create_benchmark(blas_benchmark::Args& args, blas::SB_Handle* sb_handle_ptr,
-                      bool* success) {
+void create_benchmark(blas_benchmark::Args& args,
+                      blas::SB_Handle* sb_handle_ptr, bool* success) {
   BLAS_REGISTER_BENCHMARK(args, sb_handle_ptr, success);
 }
 }  // namespace blas_benchmark

--- a/src/sb_handle/portblas_handle.hpp
+++ b/src/sb_handle/portblas_handle.hpp
@@ -122,9 +122,9 @@ inline typename SB_Handle::event_t SB_Handle::execute(
        typename lhs_t::value_t > (sharedSize, q_);
 
   auto opShMem1 =
-      make_vector_view(shMem1, typename rhs_t::index_t{1}, sharedSize);
+      make_vector_view(shMem1, typename lhs_t::increment_t(1), sharedSize);
   auto opShMem2 =
-      make_vector_view(shMem2, typename rhs_t::index_t{1}, sharedSize);
+      make_vector_view(shMem2, typename lhs_t::increment_t(1), sharedSize);
   typename SB_Handle::event_t event;
   bool frst = true;
   bool even = false;

--- a/test/unittest/blas2/blas2_spr2_test.cpp
+++ b/test/unittest/blas2/blas2_spr2_test.cpp
@@ -32,10 +32,10 @@ using combination_t =
 template <typename scalar_t, helper::AllocType mem_alloc>
 void run_test(const combination_t<scalar_t> combi) {
   std::string alloc;
-  int n;
+  index_t n;
   scalar_t alpha;
   char layout, uplo;
-  int incX, incY;
+  index_t incX, incY;
   std::tie(alloc, layout, uplo, n, alpha, incX, incY) = combi;
 
   const size_t x_size = 1 + (n - 1) * incX;
@@ -95,10 +95,10 @@ void run_test(const combination_t<scalar_t> combi) {
 template <typename scalar_t>
 void run_test(const combination_t<scalar_t> combi) {
   std::string alloc;
-  int n;
+  index_t n;
   scalar_t alpha;
   char layout, uplo;
-  int incX, incY;
+  index_t incX, incY;
   std::tie(alloc, layout, uplo, n, alpha, incX, incY) = combi;
 
   if (alloc == "usm") {
@@ -142,7 +142,7 @@ static std::string generate_name(
     const ::testing::TestParamInfo<combination_t<T>>& info) {
   std::string alloc;
   char layout, uplo;
-  int n, incX, incY;
+  index_t n, incX, incY;
   T alpha;
   BLAS_GENERATE_NAME(info.param, alloc, layout, uplo, n, alpha, incX, incY);
 }

--- a/test/unittest/extension/reduction_test.cpp
+++ b/test/unittest/extension/reduction_test.cpp
@@ -36,8 +36,6 @@ enum operator_t : int {
   Mean = 5,
 };
 
-using index_t = int;
-
 template <typename scalar_t>
 using combination_t = std::tuple<std::string, index_t, index_t, index_t,
                                  operator_t, reduction_dim_t, scalar_t>;


### PR DESCRIPTION
Currently if trying to build with `BLAS_INDEX_TYPES` different from `int` or with multiple values for the index type i.e. `int;long` the compilation fails.
This PR addresses this problem.