### PR TITLE
Remove ComputeCpp from CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,14 +39,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - impl: "COMPUTECPP"
-            cxx_compiler: "g++-7"
-            cc_compiler: "gcc-7"
-            target: "opencl"
-          - impl: "COMPUTECPP"
-            cxx_compiler: "clang++-6.0"
-            cc_compiler: "clang-6.0"
-            target: "opencl"
           - impl: "DPCPP"
             cxx_compiler: "/tmp/dpcpp/bin/clang++"
             cc_compiler: "/tmp/dpcpp/bin/clang"

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,6 @@ RUN bash /portBLAS/.scripts/build_OpenBLAS.sh
 RUN bash /portBLAS/.scripts/install_intel_opencl.sh
 
 # SYCL
-RUN if [ "${impl}" = 'COMPUTECPP' ]; then cd /portBLAS && bash /portBLAS/.scripts/build_computecpp.sh; fi
 RUN if [ "${impl}" = 'DPCPP' ]; then cd /portBLAS && bash /portBLAS/.scripts/build_dpcpp.sh; fi
 
 ENV COMMAND=${command}
@@ -57,14 +56,7 @@ ENV SYCL_IMPL=${impl}
 
 CMD cd /portBLAS && \
     if [ "${COMMAND}" = 'build-test' ]; then \
-      if [ "${SYCL_IMPL}" = 'COMPUTECPP' ]; then \
-        /tmp/ComputeCpp-latest/bin/computecpp_info && \
-        export COMPUTECPP_TARGET="intel:cpu" && mkdir -p build && cd build && \
-        cmake .. -DBLAS_ENABLE_STATIC_LIBRARY=ON -DGEMM_TALL_SKINNY_SUPPORT=OFF \
-        -DSYCL_COMPILER=computecpp -DComputeCpp_DIR=/tmp/ComputeCpp-latest \
-        -DCMAKE_PREFIX_PATH=/tmp/OpenBLAS/build -DCMAKE_BUILD_TYPE=Release && \
-        make -j$(nproc) && cd test && ctest -VV --timeout 1200; \
-      elif [ "${SYCL_IMPL}" = 'DPCPP' ]; then \
+      if [ "${SYCL_IMPL}" = 'DPCPP' ]; then \
         export LD_LIBRARY_PATH="/tmp/dpcpp/lib" && mkdir -p build && cd build && \
         cmake .. -DBLAS_ENABLE_STATIC_LIBRARY=ON -DGEMM_TALL_SKINNY_SUPPORT=OFF \
         -DSYCL_COMPILER=dpcpp -DCMAKE_PREFIX_PATH=/tmp/OpenBLAS/build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,16 +25,6 @@ RUN apt-get -yq update
 
 RUN pip install enum34
 
-# Clang 6.0
-RUN if [ "${c_compiler}" = 'clang-6.0' ]; then apt-get install -yq             \
-    --allow-downgrades --allow-remove-essential --allow-change-held-packages   \
-     clang-6.0 libomp-dev; fi
-
-# GCC 7
-RUN if [ "${c_compiler}" = 'gcc-7' ]; then apt-get install -yq                 \
-    --allow-downgrades --allow-remove-essential --allow-change-held-packages   \
-    g++-7 gcc-7; fi
-
 # OpenCL ICD Loader
 RUN apt-get install -yq --allow-downgrades --allow-remove-essential               \
     --allow-change-held-packages ocl-icd-opencl-dev ocl-icd-dev opencl-headers

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -5,20 +5,18 @@
 # developers can locally test changes in a (somewhat) platform-agnostic manner
 # without the usual delay that travis testing entails.
 #
-# By default, this script will compile the portBLAS with g++-7. Other compilers
-# can be enabled by changing the `CXX_COMPILER` and `CC_COMPILER` environment
-# variables, e.g.:
-#   export CXX_COMPILER=clang++-6.0
-#   export CC_COMPILER=clang-6.0
-# Targets and git "slug" are also equally configurable. By default, the target
-# is OpenCL, and the git repository cloned is codeplay's portBLAS master.
+# By default, this script will compile the portBLAS with open source DPCPP
+# implementation. Other compilers can be enabled by changing the `CXX_COMPILER`
+# and `CC_COMPILER` environment variables.
+# Git "slug" are also equally configurable. By default the git repository
+# cloned is codeplay's portBLAS master.
 
-export IMPL=COMPUTECPP
-export CXX_COMPILER=g++-7
-export CC_COMPILER=gcc-7
-export TARGET=opencl
+export IMPL=DPCPP
+export CXX_COMPILER="/tmp/dpcpp/bin/clang++"
+export CC_COMPILER="/tmp/dpcpp/bin/clang"
 export GIT_SLUG="codeplaysoftware/portBLAS"
 export GIT_BRANCH="master"
+export COMMAND="build-test"
 
 
 docker build --build-arg c_compiler=${CC_COMPILER} \
@@ -26,7 +24,7 @@ docker build --build-arg c_compiler=${CC_COMPILER} \
     --build-arg git_branch=${GIT_BRANCH} \
     --build-arg git_slug=${GIT_SLUG} \
     --build-arg impl=${IMPL} \
-    --build-arg target=${TARGET} \
-    -t portBLAS .
+    --build-arg command=${COMMAND} \
+    -t portblas .
 
-docker run portBLAS
+docker run portblas


### PR DESCRIPTION
This PR remove ComputeCpp from compilers used for testing in CI.

Removes references to it from Dockerfile and CI configuration.
Updates run_docker script to build and test portBLAS within a docker container using DPCPP. 