### PR TITLE
Add fixes and new NVIDIA gemm configurations

### DIFF
--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -469,18 +469,28 @@ elseif(${TUNING_TARGET} STREQUAL "NVIDIA_GPU")
       add_gemm_configuration(
           "float" 256 "false" "true" "true"
           128 8 8 16 16 16 2 1 1 1 1 16 16 16 cl::sycl::half float "local" "standard" "none" 1 "strided" "true")
-    endif()
-    # Non-Joint Matrix specific GEMM Configurations
-    add_gemm_configuration(
-      "${data}" 128 "false" "false" "true"
-      128 2 2 8 8 1 1 1 1 1 1 1 1 1 float float "local" "standard" "full" 1 "strided" "false")
-    add_gemm_configuration(
+      add_gemm_configuration(
         "${data}"  64 "false" "false" "true"
           64 8 8 8 8 1 1 2 2 1 1 1 1 1 float float "local" "standard" "full" 1 "strided" "false")
+    endif()
+
+    # Non-Joint Matrix specific GEMM Configurations
     add_gemm_configuration(
       "${data}" 64 "false" "false" "false"
       64 2 2 4 4 1 1 1 1 4 4 1 1 1 float float "no_local" "standard" "full" 4 "interleaved" "false")
-  endforeach()
+    add_gemm_configuration(
+        "${data}" 128 "false" "true" "true"
+      128 2 2 16 8 1 1 1 1 1 1 1 1 1 float float "local" "standard" "full" 1 "strided" "false")
+    add_gemm_configuration(
+        "${data}" 128 "false" "true" "true"
+      128 4 4 16 8 1 1 1 1 1 1 1 1 1 float float "local" "standard" "full" 1 "strided" "false")
+     add_gemm_configuration(
+        "${data}" 128 "false" "true" "true"
+      128 8 8 16 8 1 1 1 1 1 1 1 1 1 float float "local" "standard" "full" 1 "strided" "false")
+    add_gemm_configuration(
+        "${data}" 256 "false" "true" "true"
+      128 8 8 16 16 1 1 1 1 1 1 1 1 1 float float "local" "standard" "full" 1 "strided" "false")
+    endforeach()
 else() # default cpu backend
   set(supported_types
     "float"

--- a/src/interface/blas3/backend/nvidia_gpu.hpp
+++ b/src/interface/blas3/backend/nvidia_gpu.hpp
@@ -100,11 +100,50 @@ typename sb_handle_t::event_t _gemm(
                                        _ldc, _stridec, batch_size,
                                        _dependencies);
     }
-  } else {
+  }
+#endif  // SB_ENABLE_JOINT_MATRIX
+
+  if (batch_size > 1) {
     return blas::Gemm_Launcher<
-        container_0_t, container_1_t, container_2_t, 64, false, false, true, 64,
-        Tile<8, 8, 8, 8, 1, 1, 2, 2, 1, 1, 1, 1, 1, float, float>, _t_a, _t_b,
-        s_a, s_b, static_cast<int>(gemm_memory_t::local),
+        container_0_t, container_1_t, container_2_t, 256, false, true, true,
+        128, Tile<8, 8, 16, 16, 1, 1, 1, 1, 1, 1, 1, 1, 1, float, float>, _t_a,
+        _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::local),
+        static_cast<int>(gemm_algorithm_t::standard),
+        static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
+        static_cast<int>(gemm_batch_type_t::strided),
+        false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
+                                      _stridea, _b, _ldb, _strideb, _beta, _c,
+                                      _ldc, _stridec, batch_size,
+                                      _dependencies);
+  } else if (_M <= 256 && _N <= 256) {
+    return blas::Gemm_Launcher<
+        container_0_t, container_1_t, container_2_t, 128, false, true, true,
+        128, Tile<2, 2, 16, 8, 1, 1, 1, 1, 1, 1, 1, 1, 1, float, float>, _t_a,
+        _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::local),
+        static_cast<int>(gemm_algorithm_t::standard),
+        static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
+        static_cast<int>(gemm_batch_type_t::strided),
+        false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
+                                      _stridea, _b, _ldb, _strideb, _beta, _c,
+                                      _ldc, _stridec, batch_size,
+                                      _dependencies);
+  } else if (_M <= 1024 && _N <= 1024) {
+    return blas::Gemm_Launcher<
+        container_0_t, container_1_t, container_2_t, 128, false, true, true,
+        128, Tile<4, 4, 16, 8, 1, 1, 1, 1, 1, 1, 1, 1, 1, float, float>, _t_a,
+        _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::local),
+        static_cast<int>(gemm_algorithm_t::standard),
+        static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
+        static_cast<int>(gemm_batch_type_t::strided),
+        false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
+                                      _stridea, _b, _ldb, _strideb, _beta, _c,
+                                      _ldc, _stridec, batch_size,
+                                      _dependencies);
+  } else if (_M <= 2048 && _N <= 2048) {
+    return blas::Gemm_Launcher<
+        container_0_t, container_1_t, container_2_t, 128, false, true, true,
+        128, Tile<8, 8, 16, 8, 1, 1, 1, 1, 1, 1, 1, 1, 1, float, float>, _t_a,
+        _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
         static_cast<int>(gemm_batch_type_t::strided),
@@ -114,21 +153,16 @@ typename sb_handle_t::event_t _gemm(
                                       _dependencies);
   }
 
-#else  // SB_ENABLE_JOINT_MATRIX
-  else {
-    return blas::Gemm_Launcher<
-        container_0_t, container_1_t, container_2_t, 64, false, false, true, 64,
-        Tile<8, 8, 8, 8, 1, 1, 2, 2, 1, 1, 1, 1, 1, float, float>, _t_a, _t_b,
-        s_a, s_b, static_cast<int>(gemm_memory_t::local),
-        static_cast<int>(gemm_algorithm_t::standard),
-        static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-        static_cast<int>(gemm_batch_type_t::strided),
-        false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                      _stridea, _b, _ldb, _strideb, _beta, _c,
-                                      _ldc, _stridec, batch_size,
-                                      _dependencies);
-  }
-#endif
+  return blas::Gemm_Launcher<
+      container_0_t, container_1_t, container_2_t, 256, false, true, true, 128,
+      Tile<8, 8, 16, 16, 1, 1, 1, 1, 1, 1, 1, 1, 1, float, float>, _t_a, _t_b,
+      s_a, s_b, static_cast<int>(gemm_memory_t::local),
+      static_cast<int>(gemm_algorithm_t::standard),
+      static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
+      static_cast<int>(gemm_batch_type_t::strided),
+      false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
+                                    _stridea, _b, _ldb, _strideb, _beta, _c,
+                                    _ldc, _stridec, batch_size, _dependencies);
 }
 }  // namespace backend
 }  // namespace gemm

--- a/test/unittest/blas3/blas3_gemm_test.cpp
+++ b/test/unittest/blas3/blas3_gemm_test.cpp
@@ -126,7 +126,7 @@ const auto LargeBetaNonZeroLDMatch = ::testing::Combine(
     ::testing::Values("usm", "buf"),               // allocation type
     ::testing::Values(0),                          // offset
     ::testing::Values(1),                          // batch
-    ::testing::Values(253, 511),                   // m
+    ::testing::Values(253, 511, 1024, 2048, 2200), // m
     ::testing::Values(257, 511),                   // n
     ::testing::Values(253, 511),                   // k
     ::testing::Values('n', 't'),                   // transa

--- a/tools/auto_tuner/gen/generate_combinations.py
+++ b/tools/auto_tuner/gen/generate_combinations.py
@@ -114,8 +114,7 @@ class LocalGemm(GemmParams):
         return (self.tile.group_rows % self.tile.item_cols == 0
                 and self.tile.group_cols % self.tile.item_rows == 0
                 and self.tile.group_rows * self.tile.group_cols %
-                (self.cache_size / 4) == 0 and 
-                self.tile.group_rows * self.tile.item_rows == self.tile.group_cols * self.tile.item_cols)
+                (self.cache_size / 4) == 0)
 
 
 class NonLocalGemmStrided(GemmParams):


### PR DESCRIPTION
This patch adds new configurations for improving the `gemm` performance of the `NVIDIA_GPU` target.

Moreover,
 * remove unnecessary loop unrolls that increased register utilization; 
 * allow setting rectangular local matrix sizes;
 * remove the creation of unnecessary workgroups;
 * unroll completely the matrix computation loops for the `NVIDIA_GPU` target.