### PR TITLE
Fix bug in omatcopy_batch and omatadd_batch operators

### DIFF
--- a/src/operations/extension/matcopy_batch.hpp
+++ b/src/operations/extension/matcopy_batch.hpp
@@ -86,7 +86,7 @@ Matcopy_batch<is_add, TileSize, TilePerWG, lhs_t, rhs_t,
   orig_rhs = orig_rhs + wg_row + wg_col * rhs_1_ld_ + item_id;
 
   value_t reg_rhs[TileSize];
-  const index_t alpha = alpha_;
+  const value_t alpha = alpha_;
 
   const bool is_internal_block =
       (m - wg_row >= TileSize) && (n - wg_col >= TileSize);
@@ -151,8 +151,8 @@ Matcopy_batch<is_add, TileSize, TilePerWG, lhs_t, rhs_t,
 
   value_t reg_rhs[TileSize];
   value_t reg_rhs_2[TileSize];
-  const index_t alpha = alpha_;
-  const index_t beta = beta_;
+  const value_t alpha = alpha_;
+  const value_t beta = beta_;
 
   const bool is_internal_block =
       (m - wg_row >= TileSize) && (n - wg_col >= TileSize);

--- a/test/unittest/extension/omatadd_batched_test.cpp
+++ b/test/unittest/extension/omatadd_batched_test.cpp
@@ -160,8 +160,8 @@ const auto combi =
                        ::testing::Values<char>('n', 't'),  // trans_b
                        ::testing::Values<index_t>(64, 129, 255),  // m
                        ::testing::Values<index_t>(64, 129, 255),  // n
-                       ::testing::Values<scalar_t>(2),            // alpha
-                       ::testing::Values<scalar_t>(2),            // beta
+                       ::testing::Values<scalar_t>(2.5),            // alpha
+                       ::testing::Values<scalar_t>(3.5),            // beta
                        ::testing::Values<index_t>(1, 2),          // lda_mul
                        ::testing::Values<index_t>(1, 2),          // ldb_mul
                        ::testing::Values<index_t>(1, 2, 3),       // ldc_mul

--- a/test/unittest/extension/omatcopy_batched_test.cpp
+++ b/test/unittest/extension/omatcopy_batched_test.cpp
@@ -134,7 +134,7 @@ const auto combi =
                        ::testing::Values<char>('n', 't'),         // trans
                        ::testing::Values<index_t>(64, 129, 255),  // m
                        ::testing::Values<index_t>(64, 129, 255),  // n
-                       ::testing::Values<scalar_t>(0, 2),         // alpha
+                       ::testing::Values<scalar_t>(0, 2.5),         // alpha
                        ::testing::Values<index_t>(1, 2, 3),       // ld_in_m
                        ::testing::Values<index_t>(1, 2, 3),       // ld_out_m
                        ::testing::Values<index_t>(1, 3),          // stride_in_m


### PR DESCRIPTION
This PR addresses a bug in the current `non-transpose` implementation of `omatcopy_batch` and `omatadd_batch` operators.
It sets `alpha` and `beta` values as `index_t` type instead of `value_t` type. In case of `value_t` being a floating point type, it caused an implicit cast from floating point to integer type that lead to wrong computation.
