### PR TITLE
Reuse temporary memory allocations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,7 @@ endif()
 option(BLAS_ENABLE_CONST_INPUT "Whether to enable kernel instantiation with const input buffer" ON)
 option(BLAS_ENABLE_BENCHMARK "Whether to enable benchmarking" ON)
 option(BLAS_VERIFY_BENCHMARK "Whether to verify the results of benchmarks" ON)
+option(BLAS_MEMPOOL_BENCHMARK "Whether to use the memory pool in benchmarks" OFF)
 option(BUILD_CLBLAST_BENCHMARKS "Whether to build clBLAST benchmarks" OFF)
 option(BUILD_CLBLAS_BENCHMARKS "Whether to build clBLAS benchmarks" OFF)
 option(BUILD_CUBLAS_BENCHMARKS "Whether to build cuBLAS benchmarks" OFF)
@@ -240,6 +241,7 @@ if (BLAS_BUILD_SAMPLES)
 endif()
 
 option(BLAS_ENABLE_AUTO_TUNERS "Whether to enable building GEMM auto tuners" OFF)
+option(BLAS_ENABLE_AUTO_TUNER_MEMPOOL "Whether to enable memory pool for GEMM auto tuners" OFF)
 if(${BLAS_ENABLE_AUTO_TUNERS})
   # Note that the auto tuners are very slow to compile, so we avoid adding
   # them to the ALL target.

--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ Some of the supported options are:
 | `BUILD_SHARED_LIBS` | `ON`/`OFF` | Build as shared library (`ON` by default) |
 | `ENABLE_EXPRESSION_TESTS` | `ON`/`OFF` | Build additional tests that use the header-only framework (e.g to test expression trees); `OFF` by default |
 | `BLAS_VERIFY_BENCHMARK` | `ON`/`OFF` | Verify the results of the benchmarks instead of only measuring the performance. See the documentation of the benchmarks for more details. `ON` by default |
+| `BLAS_MEMPOOL_BENCHMARK` | `ON`/`OFF` |  Determines whether to enable the scratchpad memory pool for benchmark execution. `OFF` by default |
 | `BLAS_ENABLE_CONST_INPUT` | `ON`/`OFF` | Determines whether to enable kernel instantiation with const input buffer (`ON` by default) |
 | `BLAS_ENABLE_EXTENSIONS` | `ON`/`OFF` | Determines whether to enable portBLAS extensions (`ON` by default) |
 | `BLAS_DATA_TYPES` | `half;float;double` | Determines the floating-point types to instantiate BLAS operations for. Default is `float` |

--- a/benchmark/portblas/CMakeLists.txt
+++ b/benchmark/portblas/CMakeLists.txt
@@ -96,6 +96,10 @@ foreach(portblas_bench ${sources})
   )
   target_include_directories(bench_${bench_exec} PRIVATE ${PORTBLAS_INCLUDE} ${CBLAS_INCLUDE} ${PORTBLAS_COMMON_INCLUDE_DIR})
 
+  if(BLAS_MEMPOOL_BENCHMARK)
+    target_compile_definitions(bench_${bench_exec} PRIVATE BLAS_MEMPOOL_BENCHMARK)
+  endif()
+
   if(BLAS_VERIFY_BENCHMARK)
     target_compile_definitions(bench_${bench_exec} PRIVATE BLAS_VERIFY_BENCHMARK)
     target_link_libraries(bench_${bench_exec} PRIVATE blas::blas)

--- a/benchmark/portblas/main.cpp
+++ b/benchmark/portblas/main.cpp
@@ -66,8 +66,14 @@ int main(int argc, char** argv) {
 
   utils::print_queue_information(q);
 
+#ifdef BLAS_MEMPOOL_BENCHMARK
+  blas::Temp_Mem_Pool mp(q);
+  // Create a portBLAS sb_handle from the memory pool
+  blas::SB_Handle sb_handle(&mp);
+#else
   // Create a portBLAS sb_handle from the queue
   blas::SB_Handle sb_handle(q);
+#endif
 
   // This will be set to false by a failing benchmark
   bool success = true;

--- a/include/sb_handle/portblas_handle.h
+++ b/include/sb_handle/portblas_handle.h
@@ -54,6 +54,8 @@ class SB_Handle {
         localMemorySupport_(helper::has_local_memory(q)),
         computeUnits_(helper::get_num_compute_units(q)),
         tot_size_temp_mem_(0) {}
+  SB_Handle(SB_Handle&) = delete;
+  SB_Handle operator=(SB_Handle) = delete;
 
   ~SB_Handle() {
 #ifdef VERBOSE
@@ -62,7 +64,6 @@ class SB_Handle {
 #endif
 
 #ifdef SB_ENABLE_USM
-    // synchronize with the host on destruction
     q_.wait();
 
 #ifdef VERBOSE

--- a/include/sb_handle/portblas_handle.h
+++ b/include/sb_handle/portblas_handle.h
@@ -49,7 +49,7 @@ class SB_Handle {
  public:
   using event_t = std::vector<cl::sycl::event>;
   inline SB_Handle(queue_t q)
-      : tempMemPool_(NULL),
+      : tempMemPool_(nullptr),
         q_(q),
         workGroupSize_(helper::get_work_group_size(q)),
         localMemorySupport_(helper::has_local_memory(q)),

--- a/include/sb_handle/temp_memory_pool.h
+++ b/include/sb_handle/temp_memory_pool.h
@@ -1,0 +1,112 @@
+/***************************************************************************
+ *
+ *  @license
+ *  Copyright (C) Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  portBLAS: BLAS implementation using SYCL
+ *
+ *  @filename temp_memory_pool.h
+ *
+ **************************************************************************/
+#ifndef TEMP_MEMORY_POOL_H
+#define TEMP_MEMORY_POOL_H
+
+#include <map>
+#include <mutex>
+
+namespace blas {
+class Temp_Mem_Pool {
+  using queue_t = cl::sycl::queue;
+  using event_t = std::vector<cl::sycl::event>;
+  using temp_usm_map_t = std::multimap<size_t, void*>;
+  using temp_usm_size_map_t = std::map<void*, size_t>;
+  using temp_buffer_map_t = std::multimap<size_t, cl::sycl::buffer<int8_t, 1>>;
+
+ public:
+  Temp_Mem_Pool(queue_t q)
+      : q_(q),
+        temp_buffer_map_tot_byte_size_(0),
+        temp_usm_map_tot_byte_size_(0) {}
+  Temp_Mem_Pool(const Temp_Mem_Pool& h) = delete;
+  Temp_Mem_Pool operator=(Temp_Mem_Pool) = delete;
+
+  ~Temp_Mem_Pool() {
+    // Wait for the completion of all the host tasks
+    q_.wait();
+
+#ifdef VERBOSE
+    std::cout << "# buffers destroyed on memory pool destruction: "
+              << temp_buffer_map_.size() << " ("
+              << temp_buffer_map_tot_byte_size_ << " bytes)" << std::endl;
+#endif
+
+#ifdef SB_ENABLE_USM
+#ifdef VERBOSE
+    std::cout << "# USM allocations freed on memory pool destruction: "
+              << temp_usm_map_.size() << " (" << temp_usm_map_tot_byte_size_
+              << " bytes)" << std::endl;
+#endif
+    for (const temp_usm_map_t::value_type& p : temp_usm_map_)
+      cl::sycl::free(p.second, q_);
+#endif
+  }
+
+  inline queue_t get_queue() const { return q_; }
+
+  template <typename value_t>
+  typename helper::AllocHelper<value_t, helper::AllocType::buffer>::type
+  acquire_buff_mem(size_t size);
+
+  template <typename container_t>
+  typename Temp_Mem_Pool::event_t release_buff_mem(
+      const typename Temp_Mem_Pool::event_t&, const container_t&);
+
+#ifdef SB_ENABLE_USM
+  template <typename value_t>
+  typename helper::AllocHelper<value_t, helper::AllocType::usm>::type
+  acquire_usm_mem(size_t size);
+
+  template <typename container_t>
+  typename Temp_Mem_Pool::event_t release_usm_mem(
+      const typename Temp_Mem_Pool::event_t&, const container_t&);
+#endif
+
+ private:
+  static_assert(sizeof(temp_buffer_map_t::mapped_type::value_type) == 1);
+
+  static constexpr size_t max_size_temp_mem_ = 1e9;
+  queue_t q_;
+
+  std::mutex temp_buffer_map_mutex_;
+  size_t temp_buffer_map_tot_byte_size_;
+  temp_buffer_map_t temp_buffer_map_;
+
+  template <typename container_t>
+  void release_usm_mem_(const container_t& mem);
+
+#ifdef SB_ENABLE_USM
+  std::mutex temp_usm_map_mutex_;
+  size_t temp_usm_map_tot_byte_size_;
+  temp_usm_map_t temp_usm_map_;
+  temp_usm_size_map_t temp_usm_size_map_;
+
+  template <typename container_t>
+  void release_buff_mem_(const container_t& mem);
+#endif
+};
+}  // namespace blas
+#endif

--- a/src/interface/blas1_interface.hpp
+++ b/src/interface/blas1_interface.hpp
@@ -321,9 +321,10 @@ typename sb_handle_t::event_t _iamax_iamin_impl(
         localMemSize == 0
             ? _nWG * (static_cast<index_t>(localSize) / min_sg_size)
             : _nWG;
-    auto gpu_res = blas::helper::allocate < is_usm ? helper::AllocType::usm
-                                                   : helper::AllocType::buffer,
-         tuple_t > (memory_size, q);
+    auto gpu_res = sb_handle.template acquire_temp_mem < is_usm
+                       ? helper::AllocType::usm
+                       : helper::AllocType::buffer,
+         tuple_t > (memory_size);
     auto gpu_res_vec =
         make_vector_view(gpu_res, static_cast<increment_t>(1), memory_size);
     auto step0 = make_index_max_min<is_max, true>(gpu_res_vec, tupOp);
@@ -355,7 +356,7 @@ typename sb_handle_t::event_t _iamax_iamin_impl(
                                  static_cast<index_t>(localSize),
                                  static_cast<index_t>(localMemSize), ret));
     }
-    blas::helper::enqueue_deallocate(ret, gpu_res, q);
+    sb_handle.template release_temp_mem({*ret.rbegin()}, gpu_res);
   }
   return ret;
 }

--- a/src/interface/trsm_interface.hpp
+++ b/src/interface/trsm_interface.hpp
@@ -382,14 +382,15 @@ typename sb_handle_t::event_t _trsm(
   }
 
   // Copy bufferX to bufferB as the TRSM result
+  typename sb_handle_t::event_t lastEvent;
   trsmEvents = concatenate_vectors(
-      trsmEvents,
-      internal::_copy<sb_handle_t, index_t, decltype(X), decltype(B), index_t>(
-          sb_handle, BSize, X, 1, B, 1, trsmEvents));
+      trsmEvents, lastEvent = internal::_copy<sb_handle_t, index_t, decltype(X),
+                                              decltype(B), index_t>(
+                      sb_handle, BSize, X, 1, B, 1, trsmEvents));
 
-  sb_handle.template release_temp_mem(trsmEvents, invA);
+  sb_handle.template release_temp_mem(lastEvent, invA);
 
-  sb_handle.template release_temp_mem(trsmEvents, X);
+  sb_handle.template release_temp_mem(lastEvent, X);
 
   return trsmEvents;
 }

--- a/src/sb_handle/portblas_handle.hpp
+++ b/src/sb_handle/portblas_handle.hpp
@@ -44,7 +44,7 @@ typename std::enable_if<
     alloc == helper::AllocType::buffer,
     typename helper::AllocHelper<value_t, alloc>::type>::type
 SB_Handle::acquire_temp_mem(size_t size) {
-  if (tempMemPool_ != NULL)
+  if (tempMemPool_ != nullptr)
     return tempMemPool_->acquire_buff_mem<value_t>(size);
   else
     return make_sycl_iterator_buffer<value_t>(size);
@@ -58,7 +58,7 @@ typename std::enable_if<
     typename SB_Handle::event_t>::type
 SB_Handle::release_temp_mem(const typename SB_Handle::event_t& dependencies,
                             const container_t& mem) {
-  if (tempMemPool_ != NULL)
+  if (tempMemPool_ != nullptr)
     return tempMemPool_->release_buff_mem(dependencies, mem);
   else
     return {};
@@ -70,7 +70,7 @@ typename std::enable_if<
     alloc == helper::AllocType::usm,
     typename helper::AllocHelper<value_t, alloc>::type>::type
 SB_Handle::acquire_temp_mem(size_t size) {
-  if (tempMemPool_ != NULL)
+  if (tempMemPool_ != nullptr)
     return tempMemPool_->acquire_usm_mem<value_t>(size);
   else
     return cl::sycl::malloc_device<value_t>(size, q_);
@@ -84,7 +84,7 @@ typename std::enable_if<
     typename SB_Handle::event_t>::type
 SB_Handle::release_temp_mem(const typename SB_Handle::event_t& dependencies,
                             const container_t& mem) {
-  if (tempMemPool_ != NULL)
+  if (tempMemPool_ != nullptr)
     return tempMemPool_->release_usm_mem(dependencies, mem);
   else {
     cl::sycl::context context = q_.get_context();

--- a/src/sb_handle/temp_memory_pool.hpp
+++ b/src/sb_handle/temp_memory_pool.hpp
@@ -1,0 +1,118 @@
+#ifndef TEMP_MEMORY_POOL_HPP
+#define TEMP_MEMORY_POOL_HPP
+
+#include "portblas_helper.h"
+
+namespace blas {
+template <typename value_t>
+typename helper::AllocHelper<value_t, helper::AllocType::buffer>::type
+Temp_Mem_Pool::acquire_buff_mem(size_t size) {
+  const size_t pad = sizeof(double) / sizeof(value_t);
+  // Adjust the requested size in order to reinterpret for double's
+  size += (pad - size % pad);
+  const size_t byteSize = size * sizeof(value_t);
+  temp_buffer_map_mutex_.lock();  // lock
+  auto found = temp_buffer_map_.lower_bound(byteSize);
+  if (found != temp_buffer_map_.end()) {
+    cl::sycl::buffer<temp_buffer_map_t::mapped_type::value_type, 1> buff =
+        found->second;
+    temp_buffer_map_tot_byte_size_ -= found->first;
+    temp_buffer_map_.erase(found);
+    temp_buffer_map_mutex_.unlock();  // unlock
+    return blas::BufferIterator<value_t>{buff.reinterpret<value_t>(
+        cl::sycl::range<1>(buff.byte_size() / sizeof(value_t)))};
+  } else {
+    temp_buffer_map_mutex_.unlock();  // unlock
+#ifdef VERBOSE
+    std::cout << "Create a temporary buffer of " << byteSize << " bytes."
+              << std::endl;
+#endif
+    return make_sycl_iterator_buffer<value_t>(size);
+  }
+}
+
+template <typename container_t>
+void Temp_Mem_Pool::release_buff_mem_(const container_t& mem) {
+  const size_t byteSize = mem.get_buffer().byte_size();
+  auto rebuff =
+      mem.get_buffer()
+          .template reinterpret<temp_buffer_map_t::mapped_type::value_type>(
+              cl::sycl::range<1>(
+                  byteSize /
+                  sizeof(temp_buffer_map_t::mapped_type::value_type)));
+  temp_buffer_map_mutex_.lock();  // lock
+  if (temp_buffer_map_tot_byte_size_ + byteSize <= max_size_temp_mem_) {
+    temp_buffer_map_tot_byte_size_ += byteSize;
+    temp_buffer_map_.emplace(byteSize, rebuff);
+  }
+  temp_buffer_map_mutex_.unlock();  // unlock
+}
+
+template <typename container_t>
+typename Temp_Mem_Pool::event_t Temp_Mem_Pool::release_buff_mem(
+    const typename Temp_Mem_Pool::event_t& dependencies,
+    const container_t& mem) {
+  return {q_.submit([&](cl::sycl::handler& cgh) {
+    cgh.depends_on(dependencies);
+    cgh.host_task([&, mem]() { release_buff_mem_(mem); });
+  })};
+}
+
+#ifdef SB_ENABLE_USM
+template <typename value_t>
+typename helper::AllocHelper<value_t, helper::AllocType::usm>::type
+Temp_Mem_Pool::acquire_usm_mem(size_t size) {
+  const size_t byteSize = size * sizeof(value_t);
+  temp_usm_map_mutex_.lock();  // lock
+  auto found = temp_usm_map_.lower_bound(byteSize);
+  if (found != temp_usm_map_.end()) {
+    temp_usm_map_tot_byte_size_ -= found->first;
+    value_t* tmp = reinterpret_cast<value_t*>(found->second);
+    temp_usm_map_.erase(found);
+    temp_usm_map_mutex_.unlock();  // unlock
+    return tmp;
+  } else {
+    temp_usm_map_mutex_.unlock();  // unlock
+#ifdef VERBOSE
+    std::cout << "Create a temporary USM allocation of " << byteSize
+              << " bytes." << std::endl;
+#endif
+    value_t* tmp = cl::sycl::malloc_device<value_t>(size, q_);
+    temp_usm_map_mutex_.lock();  // lock
+    temp_usm_size_map_.emplace(
+        reinterpret_cast<temp_usm_size_map_t::key_type>(tmp), byteSize);
+    temp_usm_map_mutex_.unlock();  // unlock
+    return tmp;
+  }
+}
+
+template <typename container_t>
+void Temp_Mem_Pool::release_usm_mem_(const container_t& mem) {
+  temp_usm_map_mutex_.lock();  // lock
+  auto found = temp_usm_size_map_.find(
+      reinterpret_cast<temp_usm_size_map_t::key_type>(mem));
+  const size_t byteSize = found->second;
+  if (temp_usm_map_tot_byte_size_ + byteSize > max_size_temp_mem_) {
+    temp_usm_size_map_.erase(found);
+    temp_usm_map_mutex_.unlock();  // unlock
+    cl::sycl::free(mem, q_);
+  } else {
+    temp_usm_map_tot_byte_size_ += byteSize;
+    temp_usm_map_.emplace(byteSize,
+                          reinterpret_cast<temp_usm_map_t::mapped_type>(mem));
+    temp_usm_map_mutex_.unlock();  // unlock
+  }
+}
+
+template <typename container_t>
+typename Temp_Mem_Pool::event_t Temp_Mem_Pool::release_usm_mem(
+    const typename Temp_Mem_Pool::event_t& dependencies,
+    const container_t& mem) {
+  return {q_.submit([&](cl::sycl::handler& cgh) {
+    cgh.depends_on(dependencies);
+    cgh.host_task([&, mem]() { release_usm_mem_(mem); });
+  })};
+}
+}
+#endif
+#endif

--- a/tools/auto_tuner/CMakeLists.txt
+++ b/tools/auto_tuner/CMakeLists.txt
@@ -117,6 +117,9 @@ foreach(blas_tuner ${SYCL_AUTO_TUNNER_SRCS})
     include/
     ${CMAKE_CURRENT_BINARY_DIR}
   )
+  if(BLAS_ENABLE_AUTO_TUNER_MEMPOOL)
+    target_compile_definitions(${tuner_exec} PRIVATE BLAS_ENABLE_AUTO_TUNER_MEMPOOL)
+  endif()
   add_dependencies(${tuner_exec} tuner_generate_def_file)
   if(is_dpcpp)
     target_link_libraries(${tuner_exec} PRIVATE DPCPP::DPCPP)

--- a/tools/auto_tuner/README.md
+++ b/tools/auto_tuner/README.md
@@ -21,6 +21,17 @@ $ ninja
 
 See the Setup section in this repository's main readme for more details.
 
+Make options
+------------
+
+CMake options are given using `-D` immediately followed by the option name, the
+symbol `=` and a value (`ON` and `OFF` can be used for boolean options and are
+equivalent to 1 and 0). Example: `-DBLAS_ENABLE_TESTING=OFF`
+
+| name | value | description |
+|---|---|---|
+| `BLAS_MEMPOOL_BENCHMARK` | `ON`/`OFF` | Enable the scratchpad memory pool, useful just in case of tall skinny matrices. `OFF` by default |
+
 Usage
 -----
 

--- a/tools/auto_tuner/gen/generate_combinations.py
+++ b/tools/auto_tuner/gen/generate_combinations.py
@@ -393,7 +393,7 @@ def write_source_files(config_list, config_source, output_dir):
 #define INSTANTIATE_TUNE(DTYPE, TRA, TRB, MEM, ALGO, BATCH, VEC, ...)    \
   template TestResultEntry                                   \
   tune<__VA_ARGS__, GemmConfig<TRA, TRB, MEM, ALGO, BATCH, VEC>, DTYPE>( \
-  int r, GemmArgs<DTYPE> a);
+  portblas_handle_t &sb_handle, int r, GemmArgs<DTYPE> a);
 
 #define BENCH_PARAMS(MEM, ALGO, BATCH, VEC, ...) \
   INSTANTIATE_TUNE(float, false, false, MEM, ALGO, BATCH, VEC, __VA_ARGS__) \

--- a/tools/auto_tuner/include/tune.hpp
+++ b/tools/auto_tuner/include/tune.hpp
@@ -30,6 +30,6 @@
 
 template <int VecSize, int Cls, typename Tile, bool DoubleBuffer, bool Nbca,
           bool Nbcb, typename Config, typename T>
-TestResultEntry tune(int r, GemmArgs<T> a);
+TestResultEntry tune(portblas_handle_t &sb_handle, int r, GemmArgs<T> a);
 
 #endif  // PORTBLAS_TOOLS_AUTO_TUNER_TUNE_HPP_

--- a/tools/auto_tuner/include/tune_impl.hpp
+++ b/tools/auto_tuner/include/tune_impl.hpp
@@ -33,7 +33,7 @@
 
 template <int VecSize, int Cls, typename Tile, bool DoubleBuffer, bool Nbca,
           bool Nbcb, typename Config, typename T>
-TestResultEntry tune(int r, GemmArgs<T> a) {
+TestResultEntry tune(portblas_handle_t &sb_handle, int r, GemmArgs<T> a) {
   using Gemm = ::blas::Gemm<
       MatrixContainer<T>, MatrixContainer<T>, DoubleBuffer, Nbca, Nbcb, Cls,
       Tile, Config::TransA, Config::TransB, Config::SymmA, Config::SymmB, T,
@@ -41,7 +41,6 @@ TestResultEntry tune(int r, GemmArgs<T> a) {
       static_cast<int>(Config::ShapeMode), static_cast<int>(Config::VecType),
       VecSize, static_cast<int>(Config::BatchType)>;
   TestResultEntry result(Gemm::get_type_string());
-  auto sb_handle = get_portblas_handle();
   {
     {
       auto event = blas::helper::copy_to_device(

--- a/tools/auto_tuner/include/utils.hpp
+++ b/tools/auto_tuner/include/utils.hpp
@@ -34,7 +34,7 @@
 #include <numeric>
 #include <random>
 
-inline portblas_handle_t make_portblas_handle() {
+inline cl::sycl::queue make_sycl_queue() {
   cl::sycl::queue q(
       [=](cl::sycl::exception_list ex_list) {
         try {
@@ -50,13 +50,7 @@ inline portblas_handle_t make_portblas_handle() {
             << q.get_device().get_info<cl::sycl::info::device::name>()
             << std::endl;
 
-  portblas_handle_t sb_handle(q);
-  return sb_handle;
-}
-
-inline portblas_handle_t &get_portblas_handle() {
-  static portblas_handle_t sb_handle = make_portblas_handle();
-  return sb_handle;
+  return q;
 }
 
 template <typename T, typename RndEngine>

--- a/tools/auto_tuner/src/tune_all.cpp
+++ b/tools/auto_tuner/src/tune_all.cpp
@@ -53,15 +53,21 @@ int main(int argc, char *argv[]) {
       return -1;
     }
   }
+
+  portblas_handle_t sb_handle(make_sycl_queue());
+
   std::cout << "======= testing nn ======" << std::endl;
-  run_tune_gemm<false, false, float>(seed, m, k, n, batch_size, rep,
+  run_tune_gemm<false, false, float>(sb_handle, seed, m, k, n, batch_size, rep,
                                      batch_type);
   std::cout << "======= testing nt ======" << std::endl;
-  run_tune_gemm<false, true, float>(seed, m, k, n, batch_size, rep, batch_type);
+  run_tune_gemm<false, true, float>(sb_handle, seed, m, k, n, batch_size, rep,
+                                    batch_type);
   std::cout << "======= testing tn ======" << std::endl;
-  run_tune_gemm<true, false, float>(seed, m, k, n, batch_size, rep, batch_type);
+  run_tune_gemm<true, false, float>(sb_handle, seed, m, k, n, batch_size, rep,
+                                    batch_type);
   std::cout << "======= testing tt ======" << std::endl;
-  run_tune_gemm<true, true, float>(seed, m, k, n, batch_size, rep, batch_type);
+  run_tune_gemm<true, true, float>(sb_handle, seed, m, k, n, batch_size, rep,
+                                   batch_type);
 
   return 0;
 }

--- a/tools/auto_tuner/src/tune_all.cpp
+++ b/tools/auto_tuner/src/tune_all.cpp
@@ -54,7 +54,12 @@ int main(int argc, char *argv[]) {
     }
   }
 
+#ifdef BLAS_ENABLE_AUTO_TUNER_MEMPOOL
+  Temp_Mem_Pool mem_pool(make_sycl_queue());
+  portblas_handle_t sb_handle(&mem_pool);
+#else
   portblas_handle_t sb_handle(make_sycl_queue());
+#endif
 
   std::cout << "======= testing nn ======" << std::endl;
   run_tune_gemm<false, false, float>(sb_handle, seed, m, k, n, batch_size, rep,

--- a/tools/auto_tuner/src/tune_nn.cpp
+++ b/tools/auto_tuner/src/tune_nn.cpp
@@ -56,8 +56,11 @@ int main(int argc, char *argv[]) {
       return -1;
     }
   }
-  run_tune_gemm<transA, transB, float>(seed, m, k, n, batch_size, rep,
-                                       batch_type);
+
+  portblas_handle_t sb_handle(make_sycl_queue());
+
+  run_tune_gemm<transA, transB, float>(sb_handle, seed, m, k, n, batch_size,
+                                       rep, batch_type);
 
   return 0;
 }

--- a/tools/auto_tuner/src/tune_nn.cpp
+++ b/tools/auto_tuner/src/tune_nn.cpp
@@ -57,7 +57,12 @@ int main(int argc, char *argv[]) {
     }
   }
 
+#ifdef BLAS_ENABLE_AUTO_TUNER_MEMPOOL
+  Temp_Mem_Pool mem_pool(make_sycl_queue());
+  portblas_handle_t sb_handle(&mem_pool);
+#else
   portblas_handle_t sb_handle(make_sycl_queue());
+#endif
 
   run_tune_gemm<transA, transB, float>(sb_handle, seed, m, k, n, batch_size,
                                        rep, batch_type);

--- a/tools/auto_tuner/src/tune_nt.cpp
+++ b/tools/auto_tuner/src/tune_nt.cpp
@@ -56,8 +56,11 @@ int main(int argc, char *argv[]) {
       return -1;
     }
   }
-  run_tune_gemm<transA, transB, float>(seed, m, k, n, batch_size, rep,
-                                       batch_type);
+
+  portblas_handle_t sb_handle(make_sycl_queue());
+
+  run_tune_gemm<transA, transB, float>(sb_handle, seed, m, k, n, batch_size,
+                                       rep, batch_type);
 
   return 0;
 }

--- a/tools/auto_tuner/src/tune_nt.cpp
+++ b/tools/auto_tuner/src/tune_nt.cpp
@@ -57,7 +57,12 @@ int main(int argc, char *argv[]) {
     }
   }
 
+#ifdef BLAS_ENABLE_AUTO_TUNER_MEMPOOL
+  Temp_Mem_Pool mem_pool(make_sycl_queue());
+  portblas_handle_t sb_handle(&mem_pool);
+#else
   portblas_handle_t sb_handle(make_sycl_queue());
+#endif
 
   run_tune_gemm<transA, transB, float>(sb_handle, seed, m, k, n, batch_size,
                                        rep, batch_type);

--- a/tools/auto_tuner/src/tune_tn.cpp
+++ b/tools/auto_tuner/src/tune_tn.cpp
@@ -56,8 +56,11 @@ int main(int argc, char *argv[]) {
       return -1;
     }
   }
-  run_tune_gemm<transA, transB, float>(seed, m, k, n, batch_size, rep,
-                                       batch_type);
+
+  portblas_handle_t sb_handle(make_sycl_queue());
+
+  run_tune_gemm<transA, transB, float>(sb_handle, seed, m, k, n, batch_size,
+                                       rep, batch_type);
 
   return 0;
 }

--- a/tools/auto_tuner/src/tune_tn.cpp
+++ b/tools/auto_tuner/src/tune_tn.cpp
@@ -57,7 +57,12 @@ int main(int argc, char *argv[]) {
     }
   }
 
+#ifdef BLAS_ENABLE_AUTO_TUNER_MEMPOOL
+  Temp_Mem_Pool mem_pool(make_sycl_queue());
+  portblas_handle_t sb_handle(&mem_pool);
+#else
   portblas_handle_t sb_handle(make_sycl_queue());
+#endif
 
   run_tune_gemm<transA, transB, float>(sb_handle, seed, m, k, n, batch_size,
                                        rep, batch_type);

--- a/tools/auto_tuner/src/tune_tt.cpp
+++ b/tools/auto_tuner/src/tune_tt.cpp
@@ -56,8 +56,11 @@ int main(int argc, char *argv[]) {
       return -1;
     }
   }
-  run_tune_gemm<transA, transB, float>(seed, m, k, n, batch_size, rep,
-                                       batch_type);
+
+  portblas_handle_t sb_handle(make_sycl_queue());
+
+  run_tune_gemm<transA, transB, float>(sb_handle, seed, m, k, n, batch_size,
+                                       rep, batch_type);
 
   return 0;
 }

--- a/tools/auto_tuner/src/tune_tt.cpp
+++ b/tools/auto_tuner/src/tune_tt.cpp
@@ -57,7 +57,12 @@ int main(int argc, char *argv[]) {
     }
   }
 
+#ifdef BLAS_ENABLE_AUTO_TUNER_MEMPOOL
+  Temp_Mem_Pool mem_pool(make_sycl_queue());
+  portblas_handle_t sb_handle(&mem_pool);
+#else
   portblas_handle_t sb_handle(make_sycl_queue());
+#endif
 
   run_tune_gemm<transA, transB, float>(sb_handle, seed, m, k, n, batch_size,
                                        rep, batch_type);


### PR DESCRIPTION
This patch introduces a pool of temporary memory allocations within the `sb_handler`, which allows reusing them in order to save re-allocation time.
