### PR TITLE
Fix type comparison for joint_matrix

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -59,6 +59,3 @@ ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 SpaceBeforeParens: ControlStatements
 DisableFormat:   false
 ...
----
-Language: Json
-DisableFormat: true

--- a/include/container/sycl_iterator.h
+++ b/include/container/sycl_iterator.h
@@ -365,7 +365,7 @@ inline void BufferIterator<element_t>::set_offset(std::ptrdiff_t offset) {
  */
 template <typename element_t>
 struct ValueType<BufferIterator<element_t>> {
-  using type = element_t;
+  using type = typename std::remove_cv<element_t>::type;
 };
 /*
  * rebind the buffer iterator<U> with BufferIterator<element_t>


### PR DESCRIPTION
This patch fixes a bug identified when passing `const float` as input container type for using `joint_matrix` api in portBLAS instead of `float`. Also, I removed a few lines from `.clang-format` file which were causing error while formatting the source code.