### PR TITLE
Fixed is_device_copyable error for IndexValueTuple

### DIFF
--- a/include/operations/blas_constants.h
+++ b/include/operations/blas_constants.h
@@ -265,4 +265,16 @@ struct constant_pair {
 
 }  // namespace blas
 
+#define PORTBLAS_DEVICE_COPY(T1, T2)                             \
+  template <>                                                    \
+  struct sycl::is_device_copyable<blas::IndexValueTuple<T1, T2>> \
+      : std::true_type {};
+
+PORTBLAS_DEVICE_COPY(int32_t, float)
+PORTBLAS_DEVICE_COPY(int32_t, double)
+PORTBLAS_DEVICE_COPY(int64_t, float)
+PORTBLAS_DEVICE_COPY(int64_t, double)
+
+#undef PORTBLAS_DEVICE_COPY
+
 #endif  // BLAS_CONSTANTS_H

--- a/include/operations/blas_constants.h
+++ b/include/operations/blas_constants.h
@@ -265,16 +265,8 @@ struct constant_pair {
 
 }  // namespace blas
 
-#define PORTBLAS_DEVICE_COPY(T1, T2)                             \
-  template <>                                                    \
-  struct sycl::is_device_copyable<blas::IndexValueTuple<T1, T2>> \
-      : std::true_type {};
-
-PORTBLAS_DEVICE_COPY(int32_t, float)
-PORTBLAS_DEVICE_COPY(int32_t, double)
-PORTBLAS_DEVICE_COPY(int64_t, float)
-PORTBLAS_DEVICE_COPY(int64_t, double)
-
-#undef PORTBLAS_DEVICE_COPY
+template <typename ind_t, typename val_t>
+struct sycl::is_device_copyable<blas::IndexValueTuple<ind_t, val_t>>
+    : std::true_type {};
 
 #endif  // BLAS_CONSTANTS_H


### PR DESCRIPTION
This PR fixes the `is_device_copyable` error for `IndexValueTuple` in portBLAS. It also removes an extra file that wasn't removed previously. Applied `clang-format` to `blas2_interface.hpp` as well.