### PR TITLE
Update gemm config for CPUs & Update complex header

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
 # cancel outdated builds on pull requests.
   skip-check:
     continue-on-error: true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Map a step output to a job output
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -34,7 +34,7 @@ jobs:
   Build-and-Test:
     needs: skip-check
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.scripts/build_dpcpp.sh
+++ b/.scripts/build_dpcpp.sh
@@ -5,7 +5,7 @@ set -ev
 ###########################
 # Get DPCPP
 ###########################
-wget --no-verbose https://github.com/intel/llvm/releases/download/sycl-nightly/20230727/dpcpp-compiler.tar.gz -O dpcpp-compiler.tar.gz
+wget --no-verbose https://github.com/intel/llvm/releases/download/nightly-2023-12-06/sycl_linux.tar.gz -O dpcpp-compiler.tar.gz
 rm -rf /tmp/dpcpp && mkdir /tmp/dpcpp/
 tar -xzf dpcpp-compiler.tar.gz -C /tmp/dpcpp --strip-components 1
 ls -R /tmp/dpcpp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 # Default values for the build
 ARG command

--- a/cmake/CmakeFunctionHelper.cmake
+++ b/cmake/CmakeFunctionHelper.cmake
@@ -616,19 +616,24 @@ else() # default cpu backend
         64 8 8 8 8 1 1 1 1 1 1 1 1 1 float float "no_local" "naive" "none" 1 "strided" "false" "false")
     else()
       add_gemm_configuration(
-        "${data}"  64 "false" "false" "false"
-        64 2 2 8 8 1 1 1 1 1 1 1 1 1 float float "no_local" "standard" "full" 2 "strided" "false" "false")
+        "${data}"  128 "false" "false" "false"
+        64 2 2 2 2 1 1 1 1 1 1 1 1 1 float float "no_local" "standard" "full" 2 "strided" "false" "false")
       add_gemm_configuration(
-        "${data}"  64 "false" "false" "false"
-        64 8 8 8 8 1 1 1 1 1 1 1 1 1 float float "no_local" "standard" "partial" 1 "strided" "false" "false")
+        "${data}"  128 "false" "false" "false"
+        64 4 4 8 8 1 1 1 1 1 1 1 1 1 float float "no_local" "standard" "full" 1 "strided" "false" "false")
+      add_gemm_configuration(
+        "${data}"  128 "false" "false" "false"
+        64 4 4 4 4 1 1 1 1 1 1 1 1 1 float float "no_local" "standard" "partial" 1 "strided" "false" "false")
       add_gemm_configuration(
         "${data}"  64 "false" "false" "false"
         64 2 2 8 8 1 1 1 1 1 1 1 1 1 float float "local" "standard" "full" 2 "strided" "false" "false")
+
     endif()
 
     add_gemm_configuration(
       "${data}" 64 "false" "false" "false"
       64 2 2 4 4 1 1 1 1 4 4 1 1 1 float float "no_local" "standard" "full" 4 "interleaved" "false" "false")
+
   endforeach()
   if(BLAS_ENABLE_COMPLEX)
     # Extract list of complex<data> for each data in supported_types


### PR DESCRIPTION
This PR modifies the configuration used for our `gemm` operator implementation on CPU.

Smaller `Tile` sizes and bigger workgroup sizes lead to better performance in default benchmarks and tests.

Update complex header to fix #483 