### PR TITLE
FIx error when building with oneAPI release compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,15 @@ if (MSVC)
   )
 endif()
 
+# set -ffp-model to precise to avoid getting error statement
+# in case of icpx compiler: 
+# explicit comparison with NaN in fast floating point mode [-Werror,-Wtautological-constant-compare]
+# https://github.com/dealii/dealii/issues/14693
+string(FIND ${CMAKE_CXX_COMPILER} "icpx" found_icpx)
+if(${found_icpx} GREATER -1)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffp-model=precise")
+endif()
+
 # By default, tall and skinny Gemm is enabled (for better performance)
 option(GEMM_TALL_SKINNY_SUPPORT "Whether to enable tall and skinny Gemm" ON)
 # By default vectorization in gemm kernels is enabled as it imrpove the performance on all Devices.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,13 +83,13 @@ if (MSVC)
   )
 endif()
 
-# set -ffp-model to precise to avoid getting error statement
+# update CXX_FLAGS to avoid error when building benchmarks
 # in case of icpx compiler: 
 # explicit comparison with NaN in fast floating point mode [-Werror,-Wtautological-constant-compare]
 # https://github.com/dealii/dealii/issues/14693
 string(FIND ${CMAKE_CXX_COMPILER} "icpx" found_icpx)
-if(${found_icpx} GREATER -1)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffp-model=precise")
+if(${found_icpx} GREATER -1 AND ${BLAS_ENABLE_BENCHMARK})
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=tautological-constant-compare")
 endif()
 
 # By default, tall and skinny Gemm is enabled (for better performance)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,15 +83,6 @@ if (MSVC)
   )
 endif()
 
-# update CXX_FLAGS to avoid error when building benchmarks
-# in case of icpx compiler: 
-# explicit comparison with NaN in fast floating point mode [-Werror,-Wtautological-constant-compare]
-# https://github.com/dealii/dealii/issues/14693
-string(FIND ${CMAKE_CXX_COMPILER} "icpx" found_icpx)
-if(${found_icpx} GREATER -1 AND ${BLAS_ENABLE_BENCHMARK})
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=tautological-constant-compare")
-endif()
-
 # By default, tall and skinny Gemm is enabled (for better performance)
 option(GEMM_TALL_SKINNY_SUPPORT "Whether to enable tall and skinny Gemm" ON)
 # By default vectorization in gemm kernels is enabled as it imrpove the performance on all Devices.

--- a/benchmark/portblas/CMakeLists.txt
+++ b/benchmark/portblas/CMakeLists.txt
@@ -26,6 +26,15 @@ if(BLAS_VERIFY_BENCHMARK)
   find_package(SystemBLAS REQUIRED)
 endif()
 
+# update CXX_FLAGS to avoid error when building benchmarks
+# in case of icpx compiler: 
+# explicit comparison with NaN in fast floating point mode [-Werror,-Wtautological-constant-compare]
+# https://github.com/dealii/dealii/issues/14693
+string(FIND ${CMAKE_CXX_COMPILER} "icpx" found_icpx)
+if(${found_icpx} GREATER -1)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=tautological-constant-compare")
+endif()
+
 set(sources
   # Level 1 blas
   blas1/axpy.cpp


### PR DESCRIPTION
This PR fixes an error seen from `googlebench` and `gtest` (warning in this case) that explicit comparison with NaN is not allowed in fast precision mode.