### PR TITLE
Rectified fix for icpx error with benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -55,6 +55,16 @@ endif()
 # set BENCHMARK_ENABLE_TESTING to OFF for google bench
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
 
+# update CXX_FLAGS to avoid error when building benchmarks
+# in case of icpx compiler:
+# Explicit comparison with NaN in fast floating point mode 
+# [-Werror,-Wtautological-constant-compare]
+# https://github.com/dealii/dealii/issues/14693
+string(FIND ${CMAKE_CXX_COMPILER} "icpx" found_icpx)
+if(${found_icpx} GREATER -1)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=tautological-constant-compare")
+endif()
+
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googlebench-src
                  ${CMAKE_CURRENT_BINARY_DIR}/googlebench-build
                  EXCLUDE_FROM_ALL)

--- a/benchmark/portblas/CMakeLists.txt
+++ b/benchmark/portblas/CMakeLists.txt
@@ -26,15 +26,6 @@ if(BLAS_VERIFY_BENCHMARK)
   find_package(SystemBLAS REQUIRED)
 endif()
 
-# update CXX_FLAGS to avoid error when building benchmarks
-# in case of icpx compiler: 
-# explicit comparison with NaN in fast floating point mode [-Werror,-Wtautological-constant-compare]
-# https://github.com/dealii/dealii/issues/14693
-string(FIND ${CMAKE_CXX_COMPILER} "icpx" found_icpx)
-if(${found_icpx} GREATER -1)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=tautological-constant-compare")
-endif()
-
 set(sources
   # Level 1 blas
   blas1/axpy.cpp


### PR DESCRIPTION
This patch is based on the fix introduced at https://github.com/codeplaysoftware/portBLAS/pull/497 and moves the CMAKE_CXX_FLAGS setup to properly cover all the benchmarks and mainly the google-bench sub-repo.