### PR TITLE
Added missing bit shift operation for joint_matrix

### DIFF
--- a/test/blas_test.hpp
+++ b/test/blas_test.hpp
@@ -242,6 +242,7 @@ void set_to_zero_last_nbits(T &val, int32_t nbits = 13) {
       std::conditional_t<sizeof(T) == 64, int64_t,
                           int32_t>;
   integer_t *int_pntr = reinterpret_cast<integer_t *>(&val);
+  *int_pntr = (*int_pntr >> nbits) << nbits;
 }
 
 /**


### PR DESCRIPTION
This patch adds the required bit shift operation for `joint_matrix` which was accidentally skipped from #491 