### PR TITLE
Use cl::sycl::abs in device code

### DIFF
--- a/src/operations/blas1_trees.hpp
+++ b/src/operations/blas1_trees.hpp
@@ -448,7 +448,7 @@ PORTBLAS_INLINE bool TupleOp<rhs_t>::valid_thread(
 template <typename rhs_t>
 PORTBLAS_INLINE typename TupleOp<rhs_t>::value_t TupleOp<rhs_t>::eval(
     typename TupleOp<rhs_t>::index_t i) {
-  return TupleOp<rhs_t>::value_t(i, std::abs(rhs_.eval(i)));
+  return TupleOp<rhs_t>::value_t(i, cl::sycl::abs(rhs_.eval(i)));
 }
 
 template <typename rhs_t>


### PR DESCRIPTION
This patch turns `std::abs` in `cl::sycl::abs` for avoiding device-side compilation issues.