### PR TITLE
Apply enable-global-offset just to NVIDIA and AMD targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,14 +150,17 @@ if (INSTALL_HEADER_ONLY)
   check_cxx_compiler_flag("-fsycl" is_dpcpp)
   if(is_dpcpp)
     target_compile_definitions(portblas INTERFACE "SB_ENABLE_USM")
-    if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM"
-           AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 2024.1)
-         OR NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM")
-       # Apply only for oneAPI releases >= 2024.1 OR for intel/llvm.
-       target_link_options(portblas INTERFACE "-mllvm=-enable-global-offset=false")
-       target_compile_options(portblas INTERFACE "-mllvm=-enable-global-offset=false")
-       message(STATUS "Adding -mllvm=-enable-global-offset=false to portblas")
-     endif()
+    if ((${TUNING_TARGET} STREQUAL "NVIDIA_GPU") OR (${TUNING_TARGET} STREQUAL "AMD_GPU"))
+      # Apply only in case of NVIDIA_GPU and AMD_GPU targets.
+      if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM"
+             AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 2024.1)
+           OR NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM")
+         # Apply only for oneAPI releases >= 2024.1 OR for intel/llvm.
+         target_link_options(portblas INTERFACE "-mllvm=-enable-global-offset=false")
+         target_compile_options(portblas INTERFACE "-mllvm=-enable-global-offset=false")
+         message(STATUS "Adding -mllvm=-enable-global-offset=false to portblas")
+       endif()
+    endif()
   endif()
   if(${BLAS_ENABLE_COMPLEX})
     target_compile_definitions(portblas INTERFACE "BLAS_ENABLE_COMPLEX")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,8 +150,8 @@ if (INSTALL_HEADER_ONLY)
   check_cxx_compiler_flag("-fsycl" is_dpcpp)
   if(is_dpcpp)
     target_compile_definitions(portblas INTERFACE "SB_ENABLE_USM")
-    if ((${TUNING_TARGET} STREQUAL "NVIDIA_GPU") OR (${TUNING_TARGET} STREQUAL "AMD_GPU"))
-      # Apply only in case of NVIDIA_GPU and AMD_GPU targets.
+    check_cxx_compiler_flag("-mllvm=-enable-global-offset=false" support_disable_global_offset)
+    if (${support_disable_global_offset})
       if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM"
              AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 2024.1)
            OR NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM")

--- a/cmake/Modules/FindDPCPP.cmake
+++ b/cmake/Modules/FindDPCPP.cmake
@@ -105,7 +105,7 @@ function(add_sycl_to_target)
     target_link_options(${SB_ADD_SYCL_TARGET} PRIVATE -mllvm=-loopopt=0)
     message(STATUS "Adding -fno-fast-math -mllvm=-loopopt=0 to target ${SB_ADD_SYCL_TARGET}")
   endif()
-  if ((${TUNING_TARGET} STREQUAL "NVIDIA_GPU") OR (${TUNING_TARGET} STREQUAL "AMD_GPU"))
+  if (${DPCPP_SYCL_TARGET} MATCHES "nvidia" OR ${DPCPP_SYCL_TARGET} MATCHES "amd")
     # Apply only in case of NVIDIA_GPU and AMD_GPU targets.
     if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM"
           AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 2024.1)

--- a/cmake/Modules/FindDPCPP.cmake
+++ b/cmake/Modules/FindDPCPP.cmake
@@ -105,13 +105,16 @@ function(add_sycl_to_target)
     target_link_options(${SB_ADD_SYCL_TARGET} PRIVATE -mllvm=-loopopt=0)
     message(STATUS "Adding -fno-fast-math -mllvm=-loopopt=0 to target ${SB_ADD_SYCL_TARGET}")
   endif()
-  if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM"
-         AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 2024.1)
-       OR NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM")
-    # Apply only for oneAPI releases >= 2024.1 OR for intel/llvm.
-    target_link_options(${SB_ADD_SYCL_TARGET} PRIVATE "-mllvm=-enable-global-offset=false")
-    target_compile_options(${SB_ADD_SYCL_TARGET} PRIVATE "-mllvm=-enable-global-offset=false")
-    message(STATUS "Adding -mllvm=-enable-global-offset=false to target ${SB_ADD_SYCL_TARGET}")
+  if ((${TUNING_TARGET} STREQUAL "NVIDIA_GPU") OR (${TUNING_TARGET} STREQUAL "AMD_GPU"))
+    # Apply only in case of NVIDIA_GPU and AMD_GPU targets.
+    if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM"
+          AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 2024.1)
+        OR NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM")
+      # Apply only for oneAPI releases >= 2024.1 OR for intel/llvm.
+      target_link_options(${SB_ADD_SYCL_TARGET} PRIVATE "-mllvm=-enable-global-offset=false")
+      target_compile_options(${SB_ADD_SYCL_TARGET} PRIVATE "-mllvm=-enable-global-offset=false")
+      message(STATUS "Adding -mllvm=-enable-global-offset=false to target ${SB_ADD_SYCL_TARGET}")
+    endif()
   endif()
   target_compile_options(${SB_ADD_SYCL_TARGET} PUBLIC ${DPCPP_FLAGS})
   get_target_property(target_type ${SB_ADD_SYCL_TARGET} TYPE)


### PR DESCRIPTION
This patch restricts the application of the `enable-global-offset` flag just to NVIDIA and AMD targets since it could be not supported for other compilations.