### PR TITLE
Disable txsv intel gpu

### DIFF
--- a/include/blas_meta.h
+++ b/include/blas_meta.h
@@ -228,7 +228,7 @@ class unsupported_exception : public std::runtime_error {
       : std::runtime_error(operator_name), _msg(operator_name) {
     _msg += " operator currently not supported on selected device";
   };
-  const char *what() const noexcept { return _msg.c_str(); }
+  const char *what() const noexcept override { return _msg.c_str(); }
 
  private:
   std::string _msg{};

--- a/include/blas_meta.h
+++ b/include/blas_meta.h
@@ -222,6 +222,16 @@ struct is_complex_std
 
 #endif
 
+class unimplemented_exception : public std::runtime_error {
+ public:
+  unimplemented_exception(const std::string &err)
+      : std::runtime_error(err), _msg(err) {};
+  const char *what() const throw() { return _msg.c_str(); }
+
+ private:
+  std::string _msg{};
+};
+
 }  // namespace blas
 
 #endif  // BLAS_META_H

--- a/include/blas_meta.h
+++ b/include/blas_meta.h
@@ -226,7 +226,7 @@ class unsupported_exception : public std::runtime_error {
  public:
   unsupported_exception(const std::string &operator_name)
       : std::runtime_error(operator_name), _msg(operator_name) {
-    _msg += " operator currently not supported on Arc or GPU Max GPUs";
+    _msg += " operator currently not supported on selected device";
   };
   const char *what() const throw() { return _msg.c_str(); }
 

--- a/include/blas_meta.h
+++ b/include/blas_meta.h
@@ -222,10 +222,12 @@ struct is_complex_std
 
 #endif
 
-class unimplemented_exception : public std::runtime_error {
+class unsupported_exception : public std::runtime_error {
  public:
-  unimplemented_exception(const std::string &err)
-      : std::runtime_error(err), _msg(err) {};
+  unsupported_exception(const std::string &operator_name)
+      : std::runtime_error(operator_name), _msg(operator_name) {
+    _msg += " operator currently not supported on Arc or GPU Max GPUs";
+  };
   const char *what() const throw() { return _msg.c_str(); }
 
  private:

--- a/include/blas_meta.h
+++ b/include/blas_meta.h
@@ -228,7 +228,7 @@ class unsupported_exception : public std::runtime_error {
       : std::runtime_error(operator_name), _msg(operator_name) {
     _msg += " operator currently not supported on selected device";
   };
-  const char *what() const throw() { return _msg.c_str(); }
+  const char *what() const noexcept { return _msg.c_str(); }
 
  private:
   std::string _msg{};

--- a/include/portblas_helper.h
+++ b/include/portblas_helper.h
@@ -239,9 +239,7 @@ inline void check_intel_gpu_support(const sb_handle_t &sb_handle,
       const std::string name =
           device.template get_info<sycl::info::device::name>();
       if (name.find("Arc") != name.npos || name.find("GPU Max") != name.npos) {
-        operator_name.append(
-            " operator currently not supported on Arc or GPU Max GPUs");
-        throw unimplemented_exception(operator_name);
+        throw unsupported_exception(operator_name);
       }
     }
   }

--- a/include/portblas_helper.h
+++ b/include/portblas_helper.h
@@ -241,7 +241,7 @@ inline void check_intel_gpu_support(const sb_handle_t &sb_handle,
       if (name.find("Arc") != name.npos || name.find("GPU Max") != name.npos) {
         operator_name.append(
             " operator currently not supported on Arc or GPU Max GPUs");
-        throw std::runtime_error(operator_name);
+        throw unimplemented_exception(operator_name);
       }
     }
   }

--- a/include/portblas_helper.h
+++ b/include/portblas_helper.h
@@ -228,9 +228,14 @@ inline bool is_malloc_shared(sb_handle_t &sb_handle, const containerT _rs) {
   }
 }
 
+/*
+ @brief Check device and throw unsupported exception if Intel discrete GPU
+ @param sb_handle portBLAS handler
+ @param operator_name unsupported operator name
+ */
 template <typename sb_handle_t>
-inline void check_intel_gpu_support(const sb_handle_t &sb_handle,
-                                    std::string &&operator_name) {
+inline void throw_unsupported_intel_dGPU(const sb_handle_t &sb_handle,
+                                         std::string &&operator_name) {
   const auto device = sb_handle.get_queue().get_device();
   if (device.is_gpu()) {
     const std::string vendor =

--- a/include/portblas_helper.h
+++ b/include/portblas_helper.h
@@ -228,6 +228,25 @@ inline bool is_malloc_shared(sb_handle_t &sb_handle, const containerT _rs) {
   }
 }
 
+template <typename sb_handle_t>
+inline void check_intel_gpu_support(const sb_handle_t &sb_handle,
+                                    std::string &&operator_name) {
+  const auto device = sb_handle.get_queue().get_device();
+  if (device.is_gpu()) {
+    const std::string vendor =
+        device.template get_info<sycl::info::device::vendor>();
+    if (vendor.find("Intel") != vendor.npos) {
+      const std::string name =
+          device.template get_info<sycl::info::device::name>();
+      if (name.find("Arc") != name.npos || name.find("GPU Max") != name.npos) {
+        operator_name.append(
+            " operator currently not supported on Arc or GPU Max GPUs");
+        throw std::runtime_error(operator_name);
+      }
+    }
+  }
+}
+
 }  // end namespace helper
 }  // end namespace blas
 #endif  // PORTBLAS_HELPER_H

--- a/src/interface/blas2/backend/default.hpp
+++ b/src/interface/blas2/backend/default.hpp
@@ -145,8 +145,9 @@ typename sb_handle_t::event_t _trsv(
       return blas::internal::_trsv_impl<32, 4, uplo, trn, diag>(
           sb_handle, _N, _mA, _lda, _vx, _incx, _dependencies);
     } else {
-      throw std::runtime_error(
-          "Trsv operator currently not supported on Intel GPUs");
+      // This configuration works only for Intel iGPU
+      return blas::internal::_trsv_impl<8, 4, uplo, trn, diag>(
+          sb_handle, _N, _mA, _lda, _vx, _incx, _dependencies);
     }
   } else {
     return blas::internal::_trsv_impl<4, 2, uplo, trn, diag>(
@@ -173,8 +174,9 @@ typename sb_handle_t::event_t _tbsv(
       return blas::internal::_tbsv_impl<32, 4, uplo, trn, diag>(
           sb_handle, _N, _K, _mA, _lda, _vx, _incx, _dependencies);
     } else {
-      throw std::runtime_error(
-          "Tbsv operator currently not supported on Intel GPUs");
+      // This configuration works only for Intel iGPU
+      return blas::internal::_tbsv_impl<8, 4, uplo, trn, diag>(
+          sb_handle, _N, _K, _mA, _lda, _vx, _incx, _dependencies);
     }
   } else {
     return blas::internal::_tbsv_impl<4, 2, uplo, trn, diag>(
@@ -200,8 +202,9 @@ typename sb_handle_t::event_t _tpsv(
       return blas::internal::_tpsv_impl<32, 4, uplo, trn, diag>(
           sb_handle, _N, _mA, _vx, _incx, _dependencies);
     } else {
-      throw std::runtime_error(
-          "Tpsv operator currently not supported on Intel GPUs");
+      // This configuration works only for Intel iGPU
+      return blas::internal::_tpsv_impl<8, 4, uplo, trn, diag>(
+          sb_handle, _N, _mA, _vx, _incx, _dependencies);
     }
   } else {
     return blas::internal::_tpsv_impl<4, 2, uplo, trn, diag>(

--- a/src/interface/blas2_interface.hpp
+++ b/src/interface/blas2_interface.hpp
@@ -1253,7 +1253,7 @@ typename sb_handle_t::event_t inline _trsv(
     sb_handle_t& sb_handle, char _Uplo, char _trans, char _Diag, index_t _N,
     container_t0 _mA, index_t _lda, container_t1 _vx, increment_t _incx,
     const typename sb_handle_t::event_t& _dependencies) {
-  helper::check_intel_gpu_support(sb_handle, "trsv");
+  helper::throw_unsupported_intel_dGPU(sb_handle, "trsv");
   INST_UPLO_TRANS_DIAG(blas::trsv::backend::_trsv, sb_handle, _N, _mA, _lda,
                        _vx, _incx, _dependencies)
 }
@@ -1419,7 +1419,7 @@ typename sb_handle_t::event_t _tbsv(
     sb_handle_t& sb_handle, char _Uplo, char _trans, char _Diag, index_t _N,
     index_t _K, container_t0 _mA, index_t _lda, container_t1 _vx,
     increment_t _incx, const typename sb_handle_t::event_t& _dependencies) {
-  helper::check_intel_gpu_support(sb_handle, "tbsv");
+  helper::throw_unsupported_intel_dGPU(sb_handle, "tbsv");
   INST_UPLO_TRANS_DIAG(blas::tbsv::backend::_tbsv, sb_handle, _N, _K, _mA, _lda,
                        _vx, _incx, _dependencies)
 }
@@ -1440,7 +1440,7 @@ typename sb_handle_t::event_t _tpsv(
     sb_handle_t& sb_handle, char _Uplo, char _trans, char _Diag, index_t _N,
     container_t0 _mA, container_t1 _vx, increment_t _incx,
     const typename sb_handle_t::event_t& _dependencies) {
-  helper::check_intel_gpu_support(sb_handle, "tpsv");
+  helper::throw_unsupported_intel_dGPU(sb_handle, "tpsv");
   INST_UPLO_TRANS_DIAG(blas::tpsv::backend::_tpsv, sb_handle, _N, _mA, _vx,
                        _incx, _dependencies)
 }

--- a/src/interface/blas2_interface.hpp
+++ b/src/interface/blas2_interface.hpp
@@ -33,6 +33,7 @@
 #include "operations/blas2_trees.h"
 #include "operations/blas_constants.h"
 #include "operations/blas_operators.hpp"
+#include "portblas_helper.h"
 #include "sb_handle/portblas_handle.h"
 #include "views/view.h"
 #include <cmath>
@@ -1246,31 +1247,13 @@ typename sb_handle_t::event_t inline _trmv(
     }                                                             \
   }
 
-#define CHECK_INTEL_GPU_SUPPORT(sb_handle, func_name)                    \
-  const auto device = sb_handle.get_queue().get_device();                \
-  if (device.is_gpu()) {                                                 \
-    const std::string vendor =                                           \
-        device.template get_info<sycl::info::device::vendor>();          \
-    if (vendor.find("Intel") != vendor.npos) {                           \
-      const std::string name =                                           \
-          device.template get_info<sycl::info::device::name>();          \
-      if (name.find("Arc") != name.npos ||                               \
-          name.find("GPU Max") != name.npos) {                           \
-        std::string err_message{func_name};                              \
-        err_message.append(                                              \
-            " operator currently not supported on Arc or GPU Max GPUs"); \
-        throw std::runtime_error(err_message);                           \
-      }                                                                  \
-    }                                                                    \
-  }
-
 template <typename sb_handle_t, typename index_t, typename container_t0,
           typename container_t1, typename increment_t>
 typename sb_handle_t::event_t inline _trsv(
     sb_handle_t& sb_handle, char _Uplo, char _trans, char _Diag, index_t _N,
     container_t0 _mA, index_t _lda, container_t1 _vx, increment_t _incx,
     const typename sb_handle_t::event_t& _dependencies) {
-  CHECK_INTEL_GPU_SUPPORT(sb_handle, "trsv");
+  helper::check_intel_gpu_support(sb_handle, "trsv");
   INST_UPLO_TRANS_DIAG(blas::trsv::backend::_trsv, sb_handle, _N, _mA, _lda,
                        _vx, _incx, _dependencies)
 }
@@ -1436,7 +1419,7 @@ typename sb_handle_t::event_t _tbsv(
     sb_handle_t& sb_handle, char _Uplo, char _trans, char _Diag, index_t _N,
     index_t _K, container_t0 _mA, index_t _lda, container_t1 _vx,
     increment_t _incx, const typename sb_handle_t::event_t& _dependencies) {
-  CHECK_INTEL_GPU_SUPPORT(sb_handle, "tbsv");
+  helper::check_intel_gpu_support(sb_handle, "tbsv");
   INST_UPLO_TRANS_DIAG(blas::tbsv::backend::_tbsv, sb_handle, _N, _K, _mA, _lda,
                        _vx, _incx, _dependencies)
 }
@@ -1457,7 +1440,7 @@ typename sb_handle_t::event_t _tpsv(
     sb_handle_t& sb_handle, char _Uplo, char _trans, char _Diag, index_t _N,
     container_t0 _mA, container_t1 _vx, increment_t _incx,
     const typename sb_handle_t::event_t& _dependencies) {
-  CHECK_INTEL_GPU_SUPPORT(sb_handle, "tpsv");
+  helper::check_intel_gpu_support(sb_handle, "tpsv");
   INST_UPLO_TRANS_DIAG(blas::tpsv::backend::_tpsv, sb_handle, _N, _mA, _vx,
                        _incx, _dependencies)
 }

--- a/src/interface/blas2_interface.hpp
+++ b/src/interface/blas2_interface.hpp
@@ -1246,12 +1246,31 @@ typename sb_handle_t::event_t inline _trmv(
     }                                                             \
   }
 
+#define CHECK_INTEL_GPU_SUPPORT(sb_handle, func_name)                    \
+  const auto device = sb_handle.get_queue().get_device();                \
+  if (device.is_gpu()) {                                                 \
+    const std::string vendor =                                           \
+        device.template get_info<sycl::info::device::vendor>();          \
+    if (vendor.find("Intel") != vendor.npos) {                           \
+      const std::string name =                                           \
+          device.template get_info<sycl::info::device::name>();          \
+      if (name.find("Arc") != name.npos ||                               \
+          name.find("GPU Max") != name.npos) {                           \
+        std::string err_message{func_name};                              \
+        err_message.append(                                              \
+            " operator currently not supported on Arc or GPU Max GPUs"); \
+        throw std::runtime_error(err_message);                           \
+      }                                                                  \
+    }                                                                    \
+  }
+
 template <typename sb_handle_t, typename index_t, typename container_t0,
           typename container_t1, typename increment_t>
 typename sb_handle_t::event_t inline _trsv(
     sb_handle_t& sb_handle, char _Uplo, char _trans, char _Diag, index_t _N,
     container_t0 _mA, index_t _lda, container_t1 _vx, increment_t _incx,
     const typename sb_handle_t::event_t& _dependencies) {
+  CHECK_INTEL_GPU_SUPPORT(sb_handle, "trsv");
   INST_UPLO_TRANS_DIAG(blas::trsv::backend::_trsv, sb_handle, _N, _mA, _lda,
                        _vx, _incx, _dependencies)
 }
@@ -1417,6 +1436,7 @@ typename sb_handle_t::event_t _tbsv(
     sb_handle_t& sb_handle, char _Uplo, char _trans, char _Diag, index_t _N,
     index_t _K, container_t0 _mA, index_t _lda, container_t1 _vx,
     increment_t _incx, const typename sb_handle_t::event_t& _dependencies) {
+  CHECK_INTEL_GPU_SUPPORT(sb_handle, "tbsv");
   INST_UPLO_TRANS_DIAG(blas::tbsv::backend::_tbsv, sb_handle, _N, _K, _mA, _lda,
                        _vx, _incx, _dependencies)
 }
@@ -1437,6 +1457,7 @@ typename sb_handle_t::event_t _tpsv(
     sb_handle_t& sb_handle, char _Uplo, char _trans, char _Diag, index_t _N,
     container_t0 _mA, container_t1 _vx, increment_t _incx,
     const typename sb_handle_t::event_t& _dependencies) {
+  CHECK_INTEL_GPU_SUPPORT(sb_handle, "tpsv");
   INST_UPLO_TRANS_DIAG(blas::tpsv::backend::_tpsv, sb_handle, _N, _mA, _vx,
                        _incx, _dependencies)
 }

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -103,6 +103,16 @@ if(is_dpcpp)
   )
 endif()
 
+if( (DEFINED TUNING_TARGET AND (${TUNING_TARGET} STREQUAL "INTEL_GPU")) OR
+    (DEFINED DPCPP_SYCL_ARCH AND (${DPCPP_SYCL_ARCH} MATCHES "_pvc|_agm")) )
+    message(WARNING "disabling trsv, tbsv and tpsv tests for Intel ARC and Intel GPU Max GPUs")
+    set(TESTS_TO_SKIP
+      ${PORTBLAS_UNITTEST}/blas2/blas2_trsv_test.cpp
+      ${PORTBLAS_UNITTEST}/blas2/blas2_tbsv_test.cpp
+      ${PORTBLAS_UNITTEST}/blas2/blas2_tpsv_test.cpp
+    )
+endif()
+
 if(GEMM_TALL_SKINNY_SUPPORT)
   list(APPEND SYCL_UNITTEST_SRCS ${PORTBLAS_UNITTEST}/blas3/blas3_gemm_tall_skinny_test.cpp)
 endif()

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -103,8 +103,8 @@ if(is_dpcpp)
   )
 endif()
 
-if( (DEFINED TUNING_TARGET AND (${TUNING_TARGET} STREQUAL "INTEL_GPU")) OR
-    (DEFINED DPCPP_SYCL_ARCH AND (${DPCPP_SYCL_ARCH} MATCHES "_pvc|_agm")) )
+if( ("${TUNING_TARGET}" STREQUAL "INTEL_GPU") OR
+    ("${DPCPP_SYCL_ARCH}" MATCHES "_pvc|_agm") )
     message(WARNING "disabling trsv, tbsv and tpsv tests for Intel ARC and Intel GPU Max GPUs")
     set(TESTS_TO_SKIP
       ${PORTBLAS_UNITTEST}/blas2/blas2_trsv_test.cpp

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -103,16 +103,6 @@ if(is_dpcpp)
   )
 endif()
 
-if( ("${TUNING_TARGET}" STREQUAL "INTEL_GPU") OR
-    ("${DPCPP_SYCL_ARCH}" MATCHES "_pvc|_agm") )
-    message(WARNING "disabling trsv, tbsv and tpsv tests for Intel ARC and Intel GPU Max GPUs")
-    set(TESTS_TO_SKIP
-      ${PORTBLAS_UNITTEST}/blas2/blas2_trsv_test.cpp
-      ${PORTBLAS_UNITTEST}/blas2/blas2_tbsv_test.cpp
-      ${PORTBLAS_UNITTEST}/blas2/blas2_tpsv_test.cpp
-    )
-endif()
-
 if(GEMM_TALL_SKINNY_SUPPORT)
   list(APPEND SYCL_UNITTEST_SRCS ${PORTBLAS_UNITTEST}/blas3/blas3_gemm_tall_skinny_test.cpp)
 endif()

--- a/test/unittest/blas2/blas2_tbsv_test.cpp
+++ b/test/unittest/blas2/blas2_tbsv_test.cpp
@@ -89,7 +89,7 @@ void run_test(const combination_t<scalar_t> combi) {
         _tbsv(sb_handle, *uplo_str, *t_str, *diag_str, n, k, m_a_gpu,
               (k + 1) * lda_mul, v_x_gpu, incX, {copy_m, copy_v});
     sb_handle.wait(tbsv_event);
-  } catch (const blas::unimplemented_exception& ue) {
+  } catch (const blas::unsupported_exception& ue) {
     GTEST_SKIP();
   }
 

--- a/test/unittest/blas2/blas2_tbsv_test.cpp
+++ b/test/unittest/blas2/blas2_tbsv_test.cpp
@@ -83,11 +83,15 @@ void run_test(const combination_t<scalar_t> combi) {
   auto copy_v =
       blas::helper::copy_to_device<scalar_t>(q, x_v.data(), v_x_gpu, x_size);
 
-  // SYCL TBSV
-  auto tbsv_event =
-      _tbsv(sb_handle, *uplo_str, *t_str, *diag_str, n, k, m_a_gpu,
-            (k + 1) * lda_mul, v_x_gpu, incX, {copy_m, copy_v});
-  sb_handle.wait(tbsv_event);
+  try {
+    // SYCL TBSV
+    auto tbsv_event =
+        _tbsv(sb_handle, *uplo_str, *t_str, *diag_str, n, k, m_a_gpu,
+              (k + 1) * lda_mul, v_x_gpu, incX, {copy_m, copy_v});
+    sb_handle.wait(tbsv_event);
+  } catch (const blas::unimplemented_exception& ue) {
+    GTEST_SKIP();
+  }
 
   auto event = blas::helper::copy_to_host(sb_handle.get_queue(), v_x_gpu,
                                           x_v.data(), x_size);

--- a/test/unittest/blas2/blas2_tpsv_test.cpp
+++ b/test/unittest/blas2/blas2_tpsv_test.cpp
@@ -93,12 +93,15 @@ void run_test(const combination_t<scalar_t> combi) {
   auto copy_v =
       helper::copy_to_device<scalar_t>(q, x_v.data(), v_x_gpu, x_size);
 
-  // SYCL TPSV
-  auto tpsv_event = _tpsv(sb_handle, *uplo_str, *t_str,
-                          *diag_str, n, m_a_gpu, v_x_gpu,
-                          incX, {copy_m, copy_v});
+  try {
+    // SYCL TPSV
+    auto tpsv_event = _tpsv(sb_handle, *uplo_str, *t_str, *diag_str, n, m_a_gpu,
+                            v_x_gpu, incX, {copy_m, copy_v});
 
-  sb_handle.wait(tpsv_event);
+    sb_handle.wait(tpsv_event);
+  } catch (const blas::unimplemented_exception& ue) {
+    GTEST_SKIP();
+  }
   auto event = blas::helper::copy_to_host(sb_handle.get_queue(), v_x_gpu,
                                           x_v.data(), x_size);
   sb_handle.wait(event);

--- a/test/unittest/blas2/blas2_tpsv_test.cpp
+++ b/test/unittest/blas2/blas2_tpsv_test.cpp
@@ -99,7 +99,7 @@ void run_test(const combination_t<scalar_t> combi) {
                             v_x_gpu, incX, {copy_m, copy_v});
 
     sb_handle.wait(tpsv_event);
-  } catch (const blas::unimplemented_exception& ue) {
+  } catch (const blas::unsupported_exception& ue) {
     GTEST_SKIP();
   }
   auto event = blas::helper::copy_to_host(sb_handle.get_queue(), v_x_gpu,

--- a/test/unittest/blas2/blas2_trsv_test.cpp
+++ b/test/unittest/blas2/blas2_trsv_test.cpp
@@ -92,7 +92,7 @@ void run_test(const combination_t<scalar_t> combi) {
     auto trsv_event = _trsv(sb_handle, *uplo_str, *t_str, *diag_str, n, m_a_gpu,
                             n * lda_mul, v_x_gpu, incX, {copy_m, copy_v});
     sb_handle.wait(trsv_event);
-  } catch (const blas::unimplemented_exception& ue) {
+  } catch (const blas::unsupported_exception& ue) {
     GTEST_SKIP();
   }
 

--- a/test/unittest/blas2/blas2_trsv_test.cpp
+++ b/test/unittest/blas2/blas2_trsv_test.cpp
@@ -87,10 +87,14 @@ void run_test(const combination_t<scalar_t> combi) {
   auto copy_v =
       blas::helper::copy_to_device<scalar_t>(q, x_v.data(), v_x_gpu, x_size);
 
-  // SYCL TRSV
-  auto trsv_event = _trsv(sb_handle, *uplo_str, *t_str, *diag_str, n, m_a_gpu,
-                          n * lda_mul, v_x_gpu, incX, {copy_m, copy_v});
-  sb_handle.wait(trsv_event);
+  try {
+    // SYCL TRSV
+    auto trsv_event = _trsv(sb_handle, *uplo_str, *t_str, *diag_str, n, m_a_gpu,
+                            n * lda_mul, v_x_gpu, incX, {copy_m, copy_v});
+    sb_handle.wait(trsv_event);
+  } catch (const blas::unimplemented_exception& ue) {
+    GTEST_SKIP();
+  }
 
   auto event = blas::helper::copy_to_host(sb_handle.get_queue(), v_x_gpu,
                                           x_v.data(), x_size);


### PR DESCRIPTION
This PR disables `txsv` operators specifically for Intel ARC and Intel GPU Max GPUs by adding a runtime check on device type, vendor, and name.

The new exception is caught in our test suite, allowing us to flag the test as skipped. In cases where `TUNING_TARGET` is `INTEL_GPU` or `DPCPP_SYCL_ARCH` matches specific ARC or GPU Max targets, `txsv` tests are not added to ctest.