### PR TITLE
Remove .template to fix build

### DIFF
--- a/src/interface/blas1_interface.hpp
+++ b/src/interface/blas1_interface.hpp
@@ -355,7 +355,7 @@ typename sb_handle_t::event_t _iamax_iamin_impl(
                                  static_cast<index_t>(localSize),
                                  static_cast<index_t>(localMemSize), ret));
     }
-    sb_handle.template release_temp_mem({*ret.rbegin()}, gpu_res);
+    sb_handle.release_temp_mem({*ret.rbegin()}, gpu_res);
   }
   return ret;
 }

--- a/src/interface/blas2_interface.hpp
+++ b/src/interface/blas2_interface.hpp
@@ -140,7 +140,7 @@ typename sb_handle_t::event_t _gemv_impl(
           lastEvent = sb_handle.execute(assignOp, local_range, gemvEvent));
     }
 
-    sb_handle.template release_temp_mem(lastEvent, dot_products_buffer);
+    sb_handle.release_temp_mem(lastEvent, dot_products_buffer);
 
   } else  // Local memory kernel
   {
@@ -211,7 +211,7 @@ typename sb_handle_t::event_t _gemv_impl(
           lastEvent = sb_handle.execute(assignOp, local_range, gemvEvent));
     }
 
-    sb_handle.template release_temp_mem(lastEvent, dot_products_buffer);
+    sb_handle.release_temp_mem(lastEvent, dot_products_buffer);
   }
   return ret;
 }
@@ -341,7 +341,7 @@ typename sb_handle_t::event_t _trmv_impl(
   ret = concatenate_vectors(
       ret, lastEvent = sb_handle.execute(assignOp, localSize, ret));
 
-  sb_handle.template release_temp_mem(lastEvent, valT1);
+  sb_handle.release_temp_mem(lastEvent, valT1);
 
   return ret;
 }
@@ -403,7 +403,7 @@ typename sb_handle_t::event_t _trsv_impl(
       static_cast<index_t>(subgroup_size * (subgroup_size + 2 + sub_num)),
       _dependencies);
 
-  sb_handle.template release_temp_mem(ret, sync_buffer);
+  sb_handle.release_temp_mem(ret, sync_buffer);
 
   return ret;
 #endif
@@ -525,8 +525,8 @@ typename sb_handle_t::event_t _symv_impl(
   ret = concatenate_vectors(
       ret, lastEvent = sb_handle.execute(assignOp, localSize, ret));
 
-  sb_handle.template release_temp_mem(lastEvent, valTR);
-  sb_handle.template release_temp_mem(lastEvent, valTC);
+  sb_handle.release_temp_mem(lastEvent, valTR);
+  sb_handle.release_temp_mem(lastEvent, valTC);
 
   return ret;
 }
@@ -680,7 +680,7 @@ typename sb_handle_t::event_t _tbmv_impl(
   auto assignEvent = sb_handle.execute(assignOp, local_range, tbmvEvent);
   auto ret = concatenate_vectors(tbmvEvent, assignEvent);
 
-  sb_handle.template release_temp_mem(assignEvent, res_buffer);
+  sb_handle.release_temp_mem(assignEvent, res_buffer);
 
   return ret;
 }
@@ -735,7 +735,7 @@ typename sb_handle_t::event_t _tpmv_impl(
   auto ret = concatenate_vectors(
       tpmvEvent, lastEvent = sb_handle.execute(assignOp, tpmvEvent));
 
-  sb_handle.template release_temp_mem(lastEvent, res_buffer);
+  sb_handle.release_temp_mem(lastEvent, res_buffer);
 
   return ret;
 }
@@ -798,7 +798,7 @@ typename sb_handle_t::event_t _tbsv_impl(
       static_cast<index_t>(subgroup_size * (subgroup_size + 2 + sub_num)),
       _dependencies);
 
-  sb_handle.template release_temp_mem(ret, sync_buffer);
+  sb_handle.release_temp_mem(ret, sync_buffer);
 
   return ret;
 #endif
@@ -863,7 +863,7 @@ typename sb_handle_t::event_t _tpsv_impl(
       static_cast<index_t>(subgroup_size * (subgroup_size + 2 + sub_num)),
       _dependencies);
 
-  sb_handle.template release_temp_mem(ret, sync_buffer);
+  sb_handle.release_temp_mem(ret, sync_buffer);
 
   return ret;
 #endif

--- a/src/interface/blas3/backend/amd_gpu.hpp
+++ b/src/interface/blas3/backend/amd_gpu.hpp
@@ -62,10 +62,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
-          static_cast<int>(gemm_batch_type_t::interleaved)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::interleaved)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
     }
 
 /* Tall & Skinny matrices. */
@@ -81,10 +86,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_memory_t::local),
             static_cast<int>(gemm_algorithm_t::tall_skinny),
             static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 2,
-            static_cast<int>(gemm_batch_type_t::strided)>::
-            template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                  _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size, _dependencies);
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                           _K, _alpha, _a, _lda,
+                                                           _stridea, _b, _ldb,
+                                                           _strideb, _beta, _c,
+                                                           _ldc, _stridec,
+                                                           batch_size,
+                                                           _dependencies);
       } else if (_M > 64 && _N <= 32) {
         return blas::Gemm_Launcher<
             container_0_t, container_1_t, container_2_t, 256, true, true, true,
@@ -92,10 +101,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_memory_t::local),
             static_cast<int>(gemm_algorithm_t::tall_skinny),
             static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 2,
-            static_cast<int>(gemm_batch_type_t::strided)>::
-            template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                  _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size, _dependencies);
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                           _K, _alpha, _a, _lda,
+                                                           _stridea, _b, _ldb,
+                                                           _strideb, _beta, _c,
+                                                           _ldc, _stridec,
+                                                           batch_size,
+                                                           _dependencies);
       } else if (_M <= 16 || _N <= 16) {
         return blas::Gemm_Launcher<
             container_0_t, container_1_t, container_2_t, 256, true, true, true,
@@ -103,10 +116,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_memory_t::local),
             static_cast<int>(gemm_algorithm_t::tall_skinny),
             static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 2,
-            static_cast<int>(gemm_batch_type_t::strided)>::
-            template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                  _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size, _dependencies);
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                           _K, _alpha, _a, _lda,
+                                                           _stridea, _b, _ldb,
+                                                           _strideb, _beta, _c,
+                                                           _ldc, _stridec,
+                                                           batch_size,
+                                                           _dependencies);
       } else if (_M <= 32 || _N <= 32) {
         return blas::Gemm_Launcher<
             container_0_t, container_1_t, container_2_t, 256, true, true, true,
@@ -114,10 +131,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_memory_t::local),
             static_cast<int>(gemm_algorithm_t::tall_skinny),
             static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 2,
-            static_cast<int>(gemm_batch_type_t::strided)>::
-            template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                  _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size, _dependencies);
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                           _K, _alpha, _a, _lda,
+                                                           _stridea, _b, _ldb,
+                                                           _strideb, _beta, _c,
+                                                           _ldc, _stridec,
+                                                           batch_size,
+                                                           _dependencies);
       } else {
         return blas::Gemm_Launcher<
             container_0_t, container_1_t, container_2_t, 256, true, true, true,
@@ -125,10 +146,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_memory_t::local),
             static_cast<int>(gemm_algorithm_t::tall_skinny),
             static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 2,
-            static_cast<int>(gemm_batch_type_t::strided)>::
-            template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                  _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size, _dependencies);
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                           _K, _alpha, _a, _lda,
+                                                           _stridea, _b, _ldb,
+                                                           _strideb, _beta, _c,
+                                                           _ldc, _stridec,
+                                                           batch_size,
+                                                           _dependencies);
       }
     } else
 #endif  // GEMM_TALL_SKINNY_SUPPORT
@@ -143,10 +168,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
               static_cast<int>(gemm_memory_t::local),
               static_cast<int>(gemm_algorithm_t::standard),
               static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-              static_cast<int>(gemm_batch_type_t::strided)>::
-              template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                    _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size, _dependencies);
+              static_cast<int>(
+                  gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
         } else {
           return blas::Gemm_Launcher<
               container_0_t, container_1_t, container_2_t, 256, false, false,
@@ -154,10 +184,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
               static_cast<int>(gemm_memory_t::local),
               static_cast<int>(gemm_algorithm_t::standard),
               static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-              static_cast<int>(gemm_batch_type_t::strided)>::
-              template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                    _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size, _dependencies);
+              static_cast<int>(
+                  gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
         }
       } else if (arith_ratio >= 360) {
         return blas::Gemm_Launcher<
@@ -166,10 +201,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_memory_t::local),
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-            static_cast<int>(gemm_batch_type_t::strided)>::
-            template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                  _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size, _dependencies);
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                           _K, _alpha, _a, _lda,
+                                                           _stridea, _b, _ldb,
+                                                           _strideb, _beta, _c,
+                                                           _ldc, _stridec,
+                                                           batch_size,
+                                                           _dependencies);
       } else if (arith_ratio >= 240) {
         return blas::Gemm_Launcher<
             container_0_t, container_1_t, container_2_t, 256, false, false,
@@ -177,10 +216,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_memory_t::local),
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-            static_cast<int>(gemm_batch_type_t::strided)>::
-            template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                  _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size, _dependencies);
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                           _K, _alpha, _a, _lda,
+                                                           _stridea, _b, _ldb,
+                                                           _strideb, _beta, _c,
+                                                           _ldc, _stridec,
+                                                           batch_size,
+                                                           _dependencies);
       } else if (arith_ratio > 162) {
         return blas::Gemm_Launcher<
             container_0_t, container_1_t, container_2_t, 256, false, false,
@@ -188,10 +231,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_memory_t::local),
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-            static_cast<int>(gemm_batch_type_t::strided)>::
-            template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                  _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size, _dependencies);
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                           _K, _alpha, _a, _lda,
+                                                           _stridea, _b, _ldb,
+                                                           _strideb, _beta, _c,
+                                                           _ldc, _stridec,
+                                                           batch_size,
+                                                           _dependencies);
       } else if (arith_ratio >= 100 && arith_ratio <= 162) {
         return blas::Gemm_Launcher<
             container_0_t, container_1_t, container_2_t, 256, false, true, true,
@@ -199,10 +246,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_memory_t::local),
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-            static_cast<int>(gemm_batch_type_t::strided)>::
-            template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                  _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size, _dependencies);
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                           _K, _alpha, _a, _lda,
+                                                           _stridea, _b, _ldb,
+                                                           _strideb, _beta, _c,
+                                                           _ldc, _stridec,
+                                                           batch_size,
+                                                           _dependencies);
       } else if (arith_ratio <= 100) {
         return blas::Gemm_Launcher<
             container_0_t, container_1_t, container_2_t, 256, false, false,
@@ -210,10 +261,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_memory_t::local),
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-            static_cast<int>(gemm_batch_type_t::strided)>::
-            template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                  _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size, _dependencies);
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                           _K, _alpha, _a, _lda,
+                                                           _stridea, _b, _ldb,
+                                                           _strideb, _beta, _c,
+                                                           _ldc, _stridec,
+                                                           batch_size,
+                                                           _dependencies);
       } else {
         // this branch is a safe net just in case no other branch is taken
         return blas::Gemm_Launcher<
@@ -222,10 +277,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             s_b, static_cast<int>(gemm_memory_t::local),
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 2,
-            static_cast<int>(gemm_batch_type_t::strided)>::
-            template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                  _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                  _stridec, batch_size, _dependencies);
+            static_cast<int>(
+                gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                           _K, _alpha, _a, _lda,
+                                                           _stridea, _b, _ldb,
+                                                           _strideb, _beta, _c,
+                                                           _ldc, _stridec,
+                                                           batch_size,
+                                                           _dependencies);
       }
   }
 }
@@ -255,10 +314,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::tall_skinny),
         static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 1,
-        static_cast<int>(gemm_batch_type_t::strided)>::
-        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
-                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size, _dependencies);
+        static_cast<int>(
+            gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                       _alpha, _a, _lda,
+                                                       _stridea, _b, _ldb,
+                                                       _strideb, _beta, _c,
+                                                       _ldc, _stridec,
+                                                       batch_size,
+                                                       _dependencies);
   }
 #endif
   if (_M * _N <= 65536) {
@@ -268,10 +331,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-        static_cast<int>(gemm_batch_type_t::strided)>::
-        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
-                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size, _dependencies);
+        static_cast<int>(
+            gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                       _alpha, _a, _lda,
+                                                       _stridea, _b, _ldb,
+                                                       _strideb, _beta, _c,
+                                                       _ldc, _stridec,
+                                                       batch_size,
+                                                       _dependencies);
   } else {
     return blas::Gemm_Launcher<
         container_0_t, container_1_t, container_2_t, 256, false, false, false,
@@ -279,10 +346,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-        static_cast<int>(gemm_batch_type_t::strided)>::
-        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
-                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size, _dependencies);
+        static_cast<int>(
+            gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                       _alpha, _a, _lda,
+                                                       _stridea, _b, _ldb,
+                                                       _strideb, _beta, _c,
+                                                       _ldc, _stridec,
+                                                       batch_size,
+                                                       _dependencies);
   }
 }
 #endif

--- a/src/interface/blas3/backend/default.hpp
+++ b/src/interface/blas3/backend/default.hpp
@@ -54,10 +54,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
-          static_cast<int>(gemm_batch_type_t::interleaved)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::interleaved)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
     }
 #if defined(NAIVE_GEMM)
     return blas::Gemm_Launcher<
@@ -66,10 +71,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
         static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::naive),
         static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 1,
-        static_cast<int>(gemm_batch_type_t::strided)>::
-        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
-                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size, _dependencies);
+        static_cast<int>(
+            gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                       _alpha, _a, _lda,
+                                                       _stridea, _b, _ldb,
+                                                       _strideb, _beta, _c,
+                                                       _ldc, _stridec,
+                                                       batch_size,
+                                                       _dependencies);
 #else
     if (_M <= 128 && _N <= 128 && _K <= 256 && !s_a && !s_b) {
       return blas::Gemm_Launcher<
@@ -78,10 +87,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 2,
-          static_cast<int>(gemm_batch_type_t::strided)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                         _alpha, _a, _lda,
+                                                         _stridea, _b, _ldb,
+                                                         _strideb, _beta, _c,
+                                                         _ldc, _stridec,
+                                                         batch_size,
+                                                         _dependencies);
     } else if ((_M * _N) >= 524288 && !s_a && !s_b) {
       return blas::Gemm_Launcher<
           container_0_t, container_1_t, container_2_t, 128, false, false, false,
@@ -89,10 +102,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 1,
-          static_cast<int>(gemm_batch_type_t::strided)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                         _alpha, _a, _lda,
+                                                         _stridea, _b, _ldb,
+                                                         _strideb, _beta, _c,
+                                                         _ldc, _stridec,
+                                                         batch_size,
+                                                         _dependencies);
     } else if (!s_a && !s_b) {
       return blas::Gemm_Launcher<
           container_0_t, container_1_t, container_2_t, 128, false, false, false,
@@ -100,10 +117,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-          static_cast<int>(gemm_batch_type_t::strided)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                         _alpha, _a, _lda,
+                                                         _stridea, _b, _ldb,
+                                                         _strideb, _beta, _c,
+                                                         _ldc, _stridec,
+                                                         batch_size,
+                                                         _dependencies);
     } else {
       return blas::Gemm_Launcher<
           container_0_t, container_1_t, container_2_t, 64, false, false, false,
@@ -111,10 +132,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 2,
-          static_cast<int>(gemm_batch_type_t::strided)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                         _alpha, _a, _lda,
+                                                         _stridea, _b, _ldb,
+                                                         _strideb, _beta, _c,
+                                                         _ldc, _stridec,
+                                                         batch_size,
+                                                         _dependencies);
     }
 
 #endif
@@ -145,10 +170,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
-          static_cast<int>(gemm_batch_type_t::interleaved)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::interleaved)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
     }
 
     return blas::Gemm_Launcher<
@@ -157,10 +187,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
         static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-        static_cast<int>(gemm_batch_type_t::strided)>::
-        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
-                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size, _dependencies);
+        static_cast<int>(
+            gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                       _alpha, _a, _lda,
+                                                       _stridea, _b, _ldb,
+                                                       _strideb, _beta, _c,
+                                                       _ldc, _stridec,
+                                                       batch_size,
+                                                       _dependencies);
   }
 }
 
@@ -184,10 +218,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
         static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-        static_cast<int>(gemm_batch_type_t::strided)>::
-        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
-                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size, _dependencies);
+        static_cast<int>(
+            gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                       _alpha, _a, _lda,
+                                                       _stridea, _b, _ldb,
+                                                       _strideb, _beta, _c,
+                                                       _ldc, _stridec,
+                                                       batch_size,
+                                                       _dependencies);
   } else {
     return blas::Gemm_Launcher<
         container_0_t, container_1_t, container_2_t, 64, false, false, false,
@@ -195,10 +233,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
         static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 1,
-        static_cast<int>(gemm_batch_type_t::strided)>::
-        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
-                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size, _dependencies);
+        static_cast<int>(
+            gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                       _alpha, _a, _lda,
+                                                       _stridea, _b, _ldb,
+                                                       _strideb, _beta, _c,
+                                                       _ldc, _stridec,
+                                                       batch_size,
+                                                       _dependencies);
   }
 }
 #endif

--- a/src/interface/blas3/backend/intel_gpu.hpp
+++ b/src/interface/blas3/backend/intel_gpu.hpp
@@ -54,10 +54,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
-          static_cast<int>(gemm_batch_type_t::interleaved)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::interleaved)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
     }
 #ifdef GEMM_TALL_SKINNY_SUPPORT
     if (!s_a && !s_b) {
@@ -71,10 +76,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
               static_cast<int>(gemm_memory_t::local),
               static_cast<int>(gemm_algorithm_t::tall_skinny),
               static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
-              static_cast<int>(gemm_batch_type_t::strided)>::
-              template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                    _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size, _dependencies);
+              static_cast<int>(
+                  gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
         } else if (_M <= 4 || _N <= 4) {
           return blas::Gemm_Launcher<
               container_0_t, container_1_t, container_2_t, 16, true, false,
@@ -82,10 +92,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
               static_cast<int>(gemm_memory_t::local),
               static_cast<int>(gemm_algorithm_t::tall_skinny),
               static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
-              static_cast<int>(gemm_batch_type_t::strided)>::
-              template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                    _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size, _dependencies);
+              static_cast<int>(
+                  gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
         } else if (_M >= 16 && _N <= 8) {
           return blas::Gemm_Launcher<
               container_0_t, container_1_t, container_2_t, 32, true, true, true,
@@ -93,10 +108,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
               static_cast<int>(gemm_memory_t::local),
               static_cast<int>(gemm_algorithm_t::tall_skinny),
               static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
-              static_cast<int>(gemm_batch_type_t::strided)>::
-              template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                    _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size, _dependencies);
+              static_cast<int>(
+                  gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
         } else if (_M <= 8 || _N <= 8) {
           return blas::Gemm_Launcher<
               container_0_t, container_1_t, container_2_t, 16, true, false,
@@ -104,10 +124,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
               static_cast<int>(gemm_memory_t::local),
               static_cast<int>(gemm_algorithm_t::tall_skinny),
               static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
-              static_cast<int>(gemm_batch_type_t::strided)>::
-              template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                    _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size, _dependencies);
+              static_cast<int>(
+                  gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
         } else if (_M <= 16 || _N <= 16) {
           return blas::Gemm_Launcher<
               container_0_t, container_1_t, container_2_t, 64, true, true, true,
@@ -115,10 +140,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
               static_cast<int>(gemm_memory_t::local),
               static_cast<int>(gemm_algorithm_t::tall_skinny),
               static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
-              static_cast<int>(gemm_batch_type_t::strided)>::
-              template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                    _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size, _dependencies);
+              static_cast<int>(
+                  gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
         } else if (_M <= 32 || _N <= 32) {
           return blas::Gemm_Launcher<
               container_0_t, container_1_t, container_2_t, 64, true, true, true,
@@ -126,10 +156,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
               static_cast<int>(gemm_memory_t::local),
               static_cast<int>(gemm_algorithm_t::tall_skinny),
               static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
-              static_cast<int>(gemm_batch_type_t::strided)>::
-              template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                    _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size, _dependencies);
+              static_cast<int>(
+                  gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
         } else {
           // Need to increase the work group size for double for the
           // launcher to be instancianted
@@ -140,10 +175,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
               static_cast<int>(gemm_memory_t::local),
               static_cast<int>(gemm_algorithm_t::tall_skinny),
               static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
-              static_cast<int>(gemm_batch_type_t::strided)>::
-              template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                    _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size, _dependencies);
+              static_cast<int>(
+                  gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
         }
       } else if (batch_size == 1 && (_t_a || (_t_b && _M * _N > 1048576))) {
         if (_M <= 64 || _N <= 64) {
@@ -153,10 +193,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
               static_cast<int>(gemm_memory_t::local),
               static_cast<int>(gemm_algorithm_t::tall_skinny),
               static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
-              static_cast<int>(gemm_batch_type_t::strided)>::
-              template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                    _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size, _dependencies);
+              static_cast<int>(
+                  gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
         } else {
           // Need to increase the work group size for double for the
           // launcher to be instancianted
@@ -167,10 +212,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
               static_cast<int>(gemm_memory_t::local),
               static_cast<int>(gemm_algorithm_t::tall_skinny),
               static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
-              static_cast<int>(gemm_batch_type_t::strided)>::
-              template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                    _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size, _dependencies);
+              static_cast<int>(
+                  gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
         }
       }
     }
@@ -182,10 +232,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
-          static_cast<int>(gemm_batch_type_t::strided)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                         _alpha, _a, _lda,
+                                                         _stridea, _b, _ldb,
+                                                         _strideb, _beta, _c,
+                                                         _ldc, _stridec,
+                                                         batch_size,
+                                                         _dependencies);
     } else if (_t_b && !_t_a && !s_a && !s_b) {
       return blas::Gemm_Launcher<
           container_0_t, container_1_t, container_2_t, 64, false, false, false,
@@ -193,10 +247,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 4,
-          static_cast<int>(gemm_batch_type_t::strided)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                         _alpha, _a, _lda,
+                                                         _stridea, _b, _ldb,
+                                                         _strideb, _beta, _c,
+                                                         _ldc, _stridec,
+                                                         batch_size,
+                                                         _dependencies);
     } else {
       return blas::Gemm_Launcher<
           container_0_t, container_1_t, container_2_t, 64, false, false, false,
@@ -204,10 +262,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
-          static_cast<int>(gemm_batch_type_t::strided)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                         _alpha, _a, _lda,
+                                                         _stridea, _b, _ldb,
+                                                         _strideb, _beta, _c,
+                                                         _ldc, _stridec,
+                                                         batch_size,
+                                                         _dependencies);
     }
   }
 }
@@ -236,10 +298,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
-          static_cast<int>(gemm_batch_type_t::interleaved)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::interleaved)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
     } else {
 #ifdef GEMM_TALL_SKINNY_SUPPORT
       if (!s_a && !s_b) {
@@ -252,10 +319,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
               static_cast<int>(gemm_memory_t::local),
               static_cast<int>(gemm_algorithm_t::tall_skinny),
               static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 4,
-              static_cast<int>(gemm_batch_type_t::strided)>::
-              template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                    _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size, _dependencies);
+              static_cast<int>(
+                  gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
         }
       }
 #endif
@@ -265,10 +337,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_memory_t::local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
-          static_cast<int>(gemm_batch_type_t::strided)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                         _alpha, _a, _lda,
+                                                         _stridea, _b, _ldb,
+                                                         _strideb, _beta, _c,
+                                                         _ldc, _stridec,
+                                                         batch_size,
+                                                         _dependencies);
     }
   }
 }
@@ -295,10 +371,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::tall_skinny),
         static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 1,
-        static_cast<int>(gemm_batch_type_t::strided)>::
-        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
-                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size, _dependencies);
+        static_cast<int>(
+            gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                       _alpha, _a, _lda,
+                                                       _stridea, _b, _ldb,
+                                                       _strideb, _beta, _c,
+                                                       _ldc, _stridec,
+                                                       batch_size,
+                                                       _dependencies);
   }
 #endif
   if (_M <= 128 && _N <= 128) {
@@ -308,10 +388,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-        static_cast<int>(gemm_batch_type_t::strided)>::
-        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
-                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size, _dependencies);
+        static_cast<int>(
+            gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                       _alpha, _a, _lda,
+                                                       _stridea, _b, _ldb,
+                                                       _strideb, _beta, _c,
+                                                       _ldc, _stridec,
+                                                       batch_size,
+                                                       _dependencies);
   } else if (_t_b && !_t_a) {
     return blas::Gemm_Launcher<
         container_0_t, container_1_t, container_2_t, 64, false, false, false,
@@ -319,10 +403,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
         static_cast<int>(gemm_memory_t::no_local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::partial), is_beta_zero, 1,
-        static_cast<int>(gemm_batch_type_t::strided)>::
-        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
-                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size, _dependencies);
+        static_cast<int>(
+            gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                       _alpha, _a, _lda,
+                                                       _stridea, _b, _ldb,
+                                                       _strideb, _beta, _c,
+                                                       _ldc, _stridec,
+                                                       batch_size,
+                                                       _dependencies);
   } else {
     return blas::Gemm_Launcher<
         container_0_t, container_1_t, container_2_t, 64, false, false, false,
@@ -330,10 +418,14 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
         static_cast<int>(gemm_memory_t::local),
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
-        static_cast<int>(gemm_batch_type_t::strided)>::
-        template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
-                              _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
-                              batch_size, _dependencies);
+        static_cast<int>(
+            gemm_batch_type_t::strided)>::_select_gemm(sb_handle, _M, _N, _K,
+                                                       _alpha, _a, _lda,
+                                                       _stridea, _b, _ldb,
+                                                       _strideb, _beta, _c,
+                                                       _ldc, _stridec,
+                                                       batch_size,
+                                                       _dependencies);
   }
 }
 #endif

--- a/src/interface/blas3/backend/nvidia_gpu.hpp
+++ b/src/interface/blas3/backend/nvidia_gpu.hpp
@@ -54,10 +54,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
-          static_cast<int>(gemm_batch_type_t::interleaved)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::interleaved)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
     }
 
 #ifdef SB_ENABLE_JOINT_MATRIX
@@ -76,10 +81,9 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 1,
             static_cast<int>(gemm_batch_type_t::strided),
-            true>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a,
-                                         _lda, _stridea, _b, _ldb, _strideb,
-                                         _beta, _c, _ldc, _stridec, batch_size,
-                                         _dependencies);
+            true>::_select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
+                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
+                                _stridec, batch_size, _dependencies);
       } else if (_M > 64 && _N > 64) {
         return blas::Gemm_Launcher<
             container_0_t, container_1_t, container_2_t, 128, false, true, true,
@@ -89,10 +93,9 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 1,
             static_cast<int>(gemm_batch_type_t::strided),
-            true>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a,
-                                         _lda, _stridea, _b, _ldb, _strideb,
-                                         _beta, _c, _ldc, _stridec, batch_size,
-                                         _dependencies);
+            true>::_select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
+                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
+                                _stridec, batch_size, _dependencies);
 
       } else {
         return blas::Gemm_Launcher<
@@ -103,10 +106,9 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::none), is_beta_zero, 1,
             static_cast<int>(gemm_batch_type_t::strided),
-            true>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a,
-                                         _lda, _stridea, _b, _ldb, _strideb,
-                                         _beta, _c, _ldc, _stridec, batch_size,
-                                         _dependencies);
+            true>::_select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
+                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
+                                _stridec, batch_size, _dependencies);
       }
     }
 #endif  // SB_ENABLE_JOINT_MATRIX
@@ -119,10 +121,9 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
           static_cast<int>(gemm_batch_type_t::strided),
-          false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                        _stridea, _b, _ldb, _strideb, _beta, _c,
-                                        _ldc, _stridec, batch_size,
-                                        _dependencies);
+          false>::_select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
+                               _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
+                               _stridec, batch_size, _dependencies);
     } else if (_M <= 256 && _N <= 256) {
       return blas::Gemm_Launcher<
           container_0_t, container_1_t, container_2_t, 128, false, true, true,
@@ -131,10 +132,9 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
           static_cast<int>(gemm_batch_type_t::strided),
-          false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                        _stridea, _b, _ldb, _strideb, _beta, _c,
-                                        _ldc, _stridec, batch_size,
-                                        _dependencies);
+          false>::_select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
+                               _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
+                               _stridec, batch_size, _dependencies);
     } else if (_M <= 1024 && _N <= 1024) {
       return blas::Gemm_Launcher<
           container_0_t, container_1_t, container_2_t, 128, false, true, true,
@@ -143,10 +143,9 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
           static_cast<int>(gemm_batch_type_t::strided),
-          false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                        _stridea, _b, _ldb, _strideb, _beta, _c,
-                                        _ldc, _stridec, batch_size,
-                                        _dependencies);
+          false>::_select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
+                               _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
+                               _stridec, batch_size, _dependencies);
     } else if (_M <= 2048 && _N <= 2048) {
       return blas::Gemm_Launcher<
           container_0_t, container_1_t, container_2_t, 128, false, true, true,
@@ -155,10 +154,9 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
           static_cast<int>(gemm_batch_type_t::strided),
-          false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                        _stridea, _b, _ldb, _strideb, _beta, _c,
-                                        _ldc, _stridec, batch_size,
-                                        _dependencies);
+          false>::_select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
+                               _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
+                               _stridec, batch_size, _dependencies);
     }
 
     return blas::Gemm_Launcher<
@@ -168,10 +166,9 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
         static_cast<int>(gemm_algorithm_t::standard),
         static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
         static_cast<int>(gemm_batch_type_t::strided),
-        false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                      _stridea, _b, _ldb, _strideb, _beta, _c,
-                                      _ldc, _stridec, batch_size,
-                                      _dependencies);
+        false>::_select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                             _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                             batch_size, _dependencies);
   }
 }
 
@@ -199,10 +196,15 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
           _t_b, s_a, s_b, static_cast<int>(gemm_memory_t::no_local),
           static_cast<int>(gemm_algorithm_t::standard),
           static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 4,
-          static_cast<int>(gemm_batch_type_t::interleaved)>::
-          template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
-                                _stridec, batch_size, _dependencies);
+          static_cast<int>(
+              gemm_batch_type_t::interleaved)>::_select_gemm(sb_handle, _M, _N,
+                                                             _K, _alpha, _a,
+                                                             _lda, _stridea, _b,
+                                                             _ldb, _strideb,
+                                                             _beta, _c, _ldc,
+                                                             _stridec,
+                                                             batch_size,
+                                                             _dependencies);
     } else {
       if (_M <= 1024 && _N <= 1024) {
         return blas::Gemm_Launcher<
@@ -212,10 +214,9 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
             static_cast<int>(gemm_batch_type_t::strided),
-            false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a,
-                                          _lda, _stridea, _b, _ldb, _strideb,
-                                          _beta, _c, _ldc, _stridec, batch_size,
-                                          _dependencies);
+            false>::_select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
+                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
+                                 _stridec, batch_size, _dependencies);
       } else {
         return blas::Gemm_Launcher<
             container_0_t, container_1_t, container_2_t, 256, false, true, true,
@@ -224,10 +225,9 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
             static_cast<int>(gemm_algorithm_t::standard),
             static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
             static_cast<int>(gemm_batch_type_t::strided),
-            false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a,
-                                          _lda, _stridea, _b, _ldb, _strideb,
-                                          _beta, _c, _ldc, _stridec, batch_size,
-                                          _dependencies);
+            false>::_select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
+                                 _stridea, _b, _ldb, _strideb, _beta, _c, _ldc,
+                                 _stridec, batch_size, _dependencies);
       }
     }
   }
@@ -253,9 +253,9 @@ _gemm(sb_handle_t& sb_handle, index_t _M, index_t _N, index_t _K,
       static_cast<int>(gemm_algorithm_t::standard),
       static_cast<int>(gemm_vectorization_t::full), is_beta_zero, 1,
       static_cast<int>(gemm_batch_type_t::strided),
-      false>::template _select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda,
-                                    _stridea, _b, _ldb, _strideb, _beta, _c,
-                                    _ldc, _stridec, batch_size, _dependencies);
+      false>::_select_gemm(sb_handle, _M, _N, _K, _alpha, _a, _lda, _stridea,
+                           _b, _ldb, _strideb, _beta, _c, _ldc, _stridec,
+                           batch_size, _dependencies);
 }
 #endif
 

--- a/src/interface/trsm_interface.hpp
+++ b/src/interface/trsm_interface.hpp
@@ -388,9 +388,9 @@ typename sb_handle_t::event_t _trsm(
                                               decltype(B), index_t>(
                       sb_handle, BSize, X, 1, B, 1, trsmEvents));
 
-  sb_handle.template release_temp_mem(lastEvent, invA);
+  sb_handle.release_temp_mem(lastEvent, invA);
 
-  sb_handle.template release_temp_mem(lastEvent, X);
+  sb_handle.release_temp_mem(lastEvent, X);
 
   return trsmEvents;
 }


### PR DESCRIPTION
Remove .template construct that prevent building with newest intel/llvm.

Fix issue #526 

[nvidia_nightly_log.txt](https://github.com/user-attachments/files/16310678/nvidia_nightly_log.txt)
[nvidia_icpx_log.txt](https://github.com/user-attachments/files/16310680/nvidia_icpx_log.txt)
