### PR TITLE
Update rotmg interface to handle issue in OpenCL CPU support

### DIFF
--- a/src/interface/blas1/rotmg.cpp.in
+++ b/src/interface/blas1/rotmg.cpp.in
@@ -72,10 +72,21 @@ template typename SB_Handle::event_t _rotmg(
     BufferIterator<${DATA_TYPE}> _y1, BufferIterator<${DATA_TYPE}> _param,
     const typename SB_Handle::event_t& dependencies);
 
+template typename SB_Handle::event_t _rotmg(
+    SB_Handle& sb_handle, BufferIterator<${DATA_TYPE}> _d1,
+    BufferIterator<${DATA_TYPE}> _d2, BufferIterator<${DATA_TYPE}> _x1,
+    ${DATA_TYPE} _y1, BufferIterator<${DATA_TYPE}> _param,
+    const typename SB_Handle::event_t& dependencies);
+
 #ifdef SB_ENABLE_USM
 template typename SB_Handle::event_t _rotmg(
     SB_Handle& sb_handle, ${DATA_TYPE} * _d1, ${DATA_TYPE} * _d2,
     ${DATA_TYPE} * _x1, ${DATA_TYPE} * _y1, ${DATA_TYPE} * _param,
+    const typename SB_Handle::event_t& dependencies);
+
+template typename SB_Handle::event_t _rotmg(
+    SB_Handle& sb_handle, ${DATA_TYPE} * _d1, ${DATA_TYPE} * _d2,
+    ${DATA_TYPE} * _x1, ${DATA_TYPE} _y1, ${DATA_TYPE} * _param,
     const typename SB_Handle::event_t& dependencies);
 #endif
 

--- a/src/interface/blas1_interface.hpp
+++ b/src/interface/blas1_interface.hpp
@@ -834,7 +834,11 @@ typename sb_handle_t::event_t _rotmg(
     // https://github.com/intel/llvm/issues/14623
     if constexpr (mem_type != helper::AllocType::buffer) copy_y1.wait();
 #endif
-    return sb_handle.execute(operation, typename sb_handle_t::event_t{copy_y1});
+    auto operator_event =
+        sb_handle.execute(operation, typename sb_handle_t::event_t{copy_y1});
+    blas::helper::enqueue_deallocate(operator_event, _y1_tmp,
+                                     sb_handle.get_queue());
+    return operator_event;
   } else {
     auto y1_view = make_vector_view(_y1, inc, vector_size);
     auto operation = Rotmg<decltype(d1_view)>(d1_view, d2_view, x1_view,

--- a/src/interface/blas1_interface.hpp
+++ b/src/interface/blas1_interface.hpp
@@ -826,12 +826,15 @@ typename sb_handle_t::event_t _rotmg(
     auto y1_view = make_vector_view(_y1_tmp, inc, vector_size);
     auto operation = Rotmg<decltype(d1_view)>(d1_view, d2_view, x1_view,
                                               y1_view, param_view);
-#if !defined(AMD_GPU) && !defined(INTEL_GPU) && !defined(NVIDIA_GPU)
+#if !defined(AMD_GPU) && !defined(NVIDIA_GPU)
     // This memcpy requires a wait to enforce synchronization for usm. This is
     // due to workaround a bug present in OpenCL backend that shows up with
     // portBLAS implementation. Otherwise event dependencies works fine. The
     // issue has been reported to intel/llvm project here:
     // https://github.com/intel/llvm/issues/14623
+    // Same issue arises on Intel ARC and Intel iGPU, not sure if Intel PVC
+    // hides the problem or it is not present. For extra safety introducing this
+    // sync.
     if constexpr (mem_type != helper::AllocType::buffer) copy_y1.wait();
 #endif
     auto operator_event =

--- a/src/interface/blas1_interface.hpp
+++ b/src/interface/blas1_interface.hpp
@@ -832,14 +832,14 @@ typename sb_handle_t::event_t _rotmg(
     // portBLAS implementation. Otherwise event dependencies works fine. The
     // issue has been reported to intel/llvm project here:
     // https://github.com/intel/llvm/issues/14623
-    copy_y1.wait();
-    auto deps = _dependencies;
+    if constexpr (mem_type != helper::AllocType::buffer) copy_y1.wait();
+    return sb_handle.execute(operation, _dependencies);
 #else
     auto deps = concatenate_vectors(_dependencies,
                                     typename sb_handle_t::event_t{copy_y1});
+    return sb_handle.execute(operation, deps);
 #endif
 
-    return sb_handle.execute(operation, deps);
   } else {
     auto y1_view = make_vector_view(_y1, inc, vector_size);
     auto operation = Rotmg<decltype(d1_view)>(d1_view, d2_view, x1_view,

--- a/test/unittest/blas1/blas1_rotmg_test.cpp
+++ b/test/unittest/blas1/blas1_rotmg_test.cpp
@@ -25,7 +25,8 @@
 
 #include "blas_test.hpp"
 
-template <typename scalar_t, helper::AllocType mem_alloc>
+template <typename scalar_t, helper::AllocType mem_alloc,
+          bool is_pointer = false>
 struct RotmgTest {
   /* Magic numbers used by the rotmg algorithm */
   static constexpr scalar_t gamma = static_cast<scalar_t>(4096.0);
@@ -57,8 +58,8 @@ struct RotmgTest {
   void validate_with_rotm();
 };
 
-template <typename scalar_t, helper::AllocType mem_alloc>
-void RotmgTest<scalar_t, mem_alloc>::run_portblas_rotmg() {
+template <typename scalar_t, helper::AllocType mem_alloc, bool is_pointer>
+void RotmgTest<scalar_t, mem_alloc, is_pointer>::run_portblas_rotmg() {
   auto q = make_queue();
   blas::SB_Handle sb_handle(q);
 
@@ -67,38 +68,48 @@ void RotmgTest<scalar_t, mem_alloc>::run_portblas_rotmg() {
   auto device_d1 = helper::allocate<mem_alloc, scalar_t>(1, q);
   auto device_d2 = helper::allocate<mem_alloc, scalar_t>(1, q);
   auto device_x1 = helper::allocate<mem_alloc, scalar_t>(1, q);
-  auto device_y1 = helper::allocate<mem_alloc, scalar_t>(1, q);
+  decltype(device_x1) device_y1;
   auto device_param = helper::allocate<mem_alloc, scalar_t>(param_size, q);
 
   auto copy_d1 = helper::copy_to_device(q, &sycl_out.d1, device_d1, 1);
   auto copy_d2 = helper::copy_to_device(q, &sycl_out.d2, device_d2, 1);
   auto copy_x1 = helper::copy_to_device(q, &sycl_out.x1, device_x1, 1);
-  auto copy_y1 = helper::copy_to_device(q, &sycl_out.y1, device_y1, 1);
   auto copy_params = helper::copy_to_device(q, sycl_out.param.data(),
                                             device_param, param_size);
 
-  auto rotmg_event =
-      _rotmg(sb_handle, device_d1, device_d2, device_x1, device_y1,
-             device_param, {copy_d1, copy_d2, copy_x1, copy_y1, copy_params});
-  sb_handle.wait(rotmg_event);
+  if constexpr (is_pointer) {
+    device_y1 = helper::allocate<mem_alloc, scalar_t>(1, q);
+    auto copy_y1 = helper::copy_to_device(q, &sycl_out.y1, device_y1, 1);
+
+    auto rotmg_event =
+        _rotmg(sb_handle, device_d1, device_d2, device_x1, device_y1,
+               device_param, {copy_d1, copy_d2, copy_x1, copy_y1, copy_params});
+    sb_handle.wait(rotmg_event);
+  } else {
+    auto rotmg_event =
+        _rotmg(sb_handle, device_d1, device_d2, device_x1, sycl_out.y1,
+               device_param, {copy_d1, copy_d2, copy_x1, copy_params});
+    sb_handle.wait(rotmg_event);
+  }
 
   auto event1 = helper::copy_to_host(q, device_d1, &sycl_out.d1, 1);
   auto event2 = helper::copy_to_host(q, device_d2, &sycl_out.d2, 1);
   auto event3 = helper::copy_to_host(q, device_x1, &sycl_out.x1, 1);
-  auto event4 = helper::copy_to_host(q, device_y1, &sycl_out.y1, 1);
-  auto event5 =
+  auto event4 =
       helper::copy_to_host(q, device_param, sycl_out.param.data(), param_size);
-  sb_handle.wait({event1, event2, event3, event4, event5});
+  sb_handle.wait({event1, event2, event3, event4});
 
   helper::deallocate<mem_alloc>(device_d1, q);
   helper::deallocate<mem_alloc>(device_d2, q);
   helper::deallocate<mem_alloc>(device_x1, q);
-  helper::deallocate<mem_alloc>(device_y1, q);
   helper::deallocate<mem_alloc>(device_param, q);
+  if constexpr (is_pointer) {
+    helper::deallocate<mem_alloc>(device_y1, q);
+  }
 }
 
-template <typename scalar_t, helper::AllocType mem_alloc>
-void RotmgTest<scalar_t, mem_alloc>::validate_with_reference() {
+template <typename scalar_t, helper::AllocType mem_alloc, bool is_pointer>
+void RotmgTest<scalar_t, mem_alloc, is_pointer>::validate_with_reference() {
   scalar_t d1_ref = input.d1;
   scalar_t d2_ref = input.d2;
   scalar_t x1_ref = input.x1;
@@ -129,8 +140,7 @@ void RotmgTest<scalar_t, mem_alloc>::validate_with_reference() {
 
   const bool isAlmostEqual = utils::almost_equal(sycl_out.d1, d1_ref) &&
                              utils::almost_equal(sycl_out.d2, d2_ref) &&
-                             utils::almost_equal(sycl_out.x1, x1_ref) &&
-                             utils::almost_equal(sycl_out.y1, y1_ref);
+                             utils::almost_equal(sycl_out.x1, x1_ref);
   ASSERT_TRUE(isAlmostEqual);
 
   /* Validate param */
@@ -175,8 +185,8 @@ void RotmgTest<scalar_t, mem_alloc>::validate_with_reference() {
  * x1_output * sqrt(d1_output) = [ h11 h12 ] * [ x1_input]
  * 0.0       * sqrt(d2_output)   [ h21 h22 ]   [ y1_input]
  */
-template <typename scalar_t, helper::AllocType mem_alloc>
-void RotmgTest<scalar_t, mem_alloc>::validate_with_rotm() {
+template <typename scalar_t, helper::AllocType mem_alloc, bool is_pointer>
+void RotmgTest<scalar_t, mem_alloc, is_pointer>::validate_with_rotm() {
   if (sycl_out.param[0] == 2 || sycl_out.d2 < 0) {
     return;
   }
@@ -200,9 +210,9 @@ void RotmgTest<scalar_t, mem_alloc>::validate_with_rotm() {
 
 template <typename scalar_t>
 using combination_t =
-    std::tuple<std::string, scalar_t, scalar_t, scalar_t, scalar_t, bool>;
+    std::tuple<std::string, scalar_t, scalar_t, scalar_t, scalar_t, bool, bool>;
 
-template <typename scalar_t, helper::AllocType mem_alloc>
+template <typename scalar_t, helper::AllocType mem_alloc, bool is_pointer>
 void run_test(const combination_t<scalar_t> combi) {
   std::string alloc;
   scalar_t d1_input;
@@ -210,11 +220,13 @@ void run_test(const combination_t<scalar_t> combi) {
   scalar_t x1_input;
   scalar_t y1_input;
   bool will_overflow;
+  bool is_pointer_unused;
 
-  std::tie(alloc, d1_input, d2_input, x1_input, y1_input, will_overflow) =
-      combi;
+  std::tie(alloc, d1_input, d2_input, x1_input, y1_input, will_overflow,
+           is_pointer_unused) = combi;
 
-  RotmgTest<scalar_t, mem_alloc> test{d1_input, d2_input, x1_input, y1_input};
+  RotmgTest<scalar_t, mem_alloc, is_pointer> test{d1_input, d2_input, x1_input,
+                                                  y1_input};
   test.run_portblas_rotmg();
 
   /* Do not test with things that might overflow or underflow. Results will
@@ -233,18 +245,25 @@ void run_test(const combination_t<scalar_t> combi) {
   scalar_t x1_input;
   scalar_t y1_input;
   bool will_overflow;
+  bool is_pointer;
 
-  std::tie(alloc, d1_input, d2_input, x1_input, y1_input, will_overflow) =
-      combi;
+  std::tie(alloc, d1_input, d2_input, x1_input, y1_input, will_overflow,
+           is_pointer) = combi;
 
   if (alloc == "usm") {  // usm alloc
 #ifdef SB_ENABLE_USM
-    run_test<scalar_t, helper::AllocType::usm>(combi);
+    if (is_pointer)
+      run_test<scalar_t, helper::AllocType::usm, true>(combi);
+    else
+      run_test<scalar_t, helper::AllocType::usm, false>(combi);
 #else
     GTEST_SKIP();
 #endif
   } else {  // buffer alloc
-    run_test<scalar_t, helper::AllocType::buffer>(combi);
+    if (is_pointer)
+      run_test<scalar_t, helper::AllocType::buffer, true>(combi);
+    else
+      run_test<scalar_t, helper::AllocType::buffer, false>(combi);
   }
 }
 
@@ -290,155 +309,170 @@ scalar_t scale_up_gen() {
 }
 
 /* This tests try to cover every code path of the rotmg algorithm */
-#define INSTANTIATE_ROTMG_TESTS(NAME, C)                                       \
+#define INSTANTIATE_ROTMG_TESTS(NAME, C, IS_POINTER)                           \
   template <typename scalar_t>                                                 \
   const auto NAME = ::testing::                                                \
       Values(/* d1 < 0 */                                                      \
              std::make_tuple(C, -2.5, p_gen<scalar_t>(), r_gen<scalar_t>(),    \
-                             r_gen<scalar_t>(),                                \
-                             false), /* Input point (c, 0) */                  \
+                             r_gen<scalar_t>(), false,                         \
+                             IS_POINTER), /* Input point (c, 0) */             \
              std::make_tuple(C, p_gen<scalar_t>(), p_gen<scalar_t>(),          \
-                             r_gen<scalar_t>(), 0.0,                           \
-                             false), /* Input point (c, 0) && d2 == 0 */       \
+                             r_gen<scalar_t>(), 0.0, false,                    \
+                             IS_POINTER), /* Input point (c, 0) && d2 == 0 */  \
              std::make_tuple(C, p_gen<scalar_t>(), 0.0, r_gen<scalar_t>(),     \
-                             0.0, false), /* Input point (c, 0) && d2 == 0 */  \
-             std::make_tuple(C, p_gen<scalar_t>(), 0.0, r_gen<scalar_t>(),     \
-                             r_gen<scalar_t>(),                                \
-                             false), /* Input point (c, 0) and big numbers     \
-                                        (test that no rescaling happened) */   \
-             std::make_tuple(C, scale_up_gen<scalar_t>(),                      \
-                             scale_up_gen<scalar_t>(),                         \
-                             scale_up_gen<scalar_t>(), 0.0, false),            \
+                             r_gen<scalar_t>(), false,                         \
+                             IS_POINTER), /* Input point (c, 0) and big        \
+                                  numbers (test that no rescaling happened) */ \
+             std::make_tuple(                                                  \
+                 C, scale_up_gen<scalar_t>(), scale_up_gen<scalar_t>(),        \
+                 scale_up_gen<scalar_t>(), 0.0, false, IS_POINTER),            \
              std::make_tuple(C, scale_down_gen<scalar_t>(),                    \
                              scale_down_gen<scalar_t>(),                       \
-                             scale_down_gen<scalar_t>(), 0.0,                  \
-                             false), /* Input point (0, c) */                  \
+                             scale_down_gen<scalar_t>(), 0.0, false,           \
+                             IS_POINTER), /* Input point (0, c) */             \
              std::make_tuple(C, p_gen<scalar_t>(), p_gen<scalar_t>(), 0.0,     \
-                             r_gen<scalar_t>(),                                \
-                             false), /* Input point (0, c) && d1 == 0 */       \
+                             r_gen<scalar_t>(), false,                         \
+                             IS_POINTER), /* Input point (0, c) && d1 == 0 */  \
              std::make_tuple(C, 0.0, p_gen<scalar_t>(), 0.0,                   \
-                             r_gen<scalar_t>(),                                \
-                             false), /* Input point (0, c) && d2 == 0 */       \
+                             r_gen<scalar_t>(), false,                         \
+                             IS_POINTER), /* Input point (0, c) && d2 == 0 */  \
              std::make_tuple(C, p_gen<scalar_t>(), 0.0, 0.0,                   \
-                             r_gen<scalar_t>(),                                \
-                             false), /* Input point (0, c) && d2 < 0 */        \
-             std::make_tuple(C, p_gen<scalar_t>(), -3.4, 0.0,                  \
-                             r_gen<scalar_t>(),                                \
-                             false), /* Input point (0, c) && rescaling */     \
-             std::make_tuple(C, p_gen<scalar_t>(), scale_up_gen<scalar_t>(),   \
-                             0.0, r_gen<scalar_t>(), false),                   \
-             std::make_tuple(C, p_gen<scalar_t>(), scale_down_gen<scalar_t>(), \
-                             0.0, r_gen<scalar_t>(), false),                   \
-             std::make_tuple(C, scale_up_gen<scalar_t>(), p_gen<scalar_t>(),   \
-                             0.0, r_gen<scalar_t>(), false),                   \
-             std::make_tuple(C, scale_down_gen<scalar_t>(), p_gen<scalar_t>(), \
-                             0.0, r_gen<scalar_t>(), false), /* d1 == 0 */     \
-             std::make_tuple(C, 0.0, p_gen<scalar_t>(), r_gen<scalar_t>(),     \
-                             r_gen<scalar_t>(),                                \
-                             false), /* d1 == 0 && d2 < 0 */                   \
+                             r_gen<scalar_t>(), false,                         \
+                             IS_POINTER), /* Input point (0, c) && d2 < 0 */   \
              std::make_tuple(                                                  \
-                 C, 0.0, -3.4, r_gen<scalar_t>(), r_gen<scalar_t>(),           \
-                 false), /* d1 * x1 > d2 * y1 (i.e. abs_c > abs_s) */          \
-             std::make_tuple(C, 4.0, 2.1, 3.4, 1.5, false),                    \
-             std::make_tuple(C, 4.0, 1.5, -3.4, 2.1, false),                   \
-             std::make_tuple(C, 4.0, -1.5, 3.4, 2.1, false),                   \
-             std::make_tuple(C, 4.0, -1.5, 3.4, -2.1, false),                  \
-             std::make_tuple(C, 4.0, -1.5, -3.4, -2.1,                         \
-                             false), /* d1 * x1 > d2 * y1 (i.e. abs_c > abs_s) \
-                                        && rescaling */                        \
+                 C, p_gen<scalar_t>(), -3.4, 0.0, r_gen<scalar_t>(), false,    \
+                 IS_POINTER), /* Input point (0, c) && rescaling */            \
+             std::make_tuple(C, p_gen<scalar_t>(), scale_up_gen<scalar_t>(),   \
+                             0.0, r_gen<scalar_t>(), false, IS_POINTER),       \
+             std::make_tuple(C, p_gen<scalar_t>(), scale_down_gen<scalar_t>(), \
+                             0.0, r_gen<scalar_t>(), false, IS_POINTER),       \
+             std::make_tuple(C, scale_up_gen<scalar_t>(), p_gen<scalar_t>(),   \
+                             0.0, r_gen<scalar_t>(), false, IS_POINTER),       \
+             std::make_tuple(C, scale_down_gen<scalar_t>(), p_gen<scalar_t>(), \
+                             0.0, r_gen<scalar_t>(), false,                    \
+                             IS_POINTER), /* d1 == 0 */                        \
+             std::make_tuple(C, 0.0, p_gen<scalar_t>(), r_gen<scalar_t>(),     \
+                             r_gen<scalar_t>(), false,                         \
+                             IS_POINTER), /* d1 == 0 && d2 < 0 */              \
+             std::make_tuple(                                                  \
+                 C, 0.0, -3.4, r_gen<scalar_t>(), r_gen<scalar_t>(), false,    \
+                 IS_POINTER), /* d1 * x1 > d2 * y1 (i.e. abs_c > abs_s) */     \
+             std::make_tuple(C, 4.0, 2.1, 3.4, 1.5, false, IS_POINTER),        \
+             std::make_tuple(C, 4.0, 1.5, -3.4, 2.1, false, IS_POINTER),       \
+             std::make_tuple(C, 4.0, -1.5, 3.4, 2.1, false, IS_POINTER),       \
+             std::make_tuple(C, 4.0, -1.5, 3.4, -2.1, false, IS_POINTER),      \
+             std::make_tuple(                                                  \
+                 C, 4.0, -1.5, -3.4, -2.1, false,                              \
+                 IS_POINTER), /* d1 * x1 > d2 * y1 (i.e. abs_c > abs_s)        \
+                     && rescaling */                                           \
              std::make_tuple(C, scale_down_gen<scalar_t>(), 2.1, 3.4, 1.5,     \
-                             false),                                           \
+                             false, IS_POINTER),                               \
              std::make_tuple(C, scale_down_gen<scalar_t>(), 2.1,               \
-                             scale_down_gen<scalar_t>(), 1.5, false),          \
+                             scale_down_gen<scalar_t>(), 1.5, false,           \
+                             IS_POINTER),                                      \
              std::make_tuple(C, scale_up_gen<scalar_t>(), 2.1,                 \
-                             scale_down_gen<scalar_t>(), 1.5, false),          \
-             std::make_tuple(C, scale_down_gen<scalar_t>(), 2.1,               \
-                             scale_up_gen<scalar_t>(), 1.5,                    \
-                             false), /* d1 * x1 > d2 * y1 (i.e. abs_c > abs_s) \
-                                        && Underflow */                        \
+                             scale_down_gen<scalar_t>(), 1.5, false,           \
+                             IS_POINTER),                                      \
+             std::make_tuple(                                                  \
+                 C, scale_down_gen<scalar_t>(), 2.1, scale_up_gen<scalar_t>(), \
+                 1.5, false,                                                   \
+                 IS_POINTER), /* d1 * x1 > d2 * y1 (i.e. abs_c > abs_s)        \
+                     && Underflow */                                           \
              std::make_tuple(C, 0.01, 0.01,                                    \
                              std::numeric_limits<scalar_t>::min(),             \
-                             std::numeric_limits<scalar_t>::min(),             \
-                             true), /* d1 * x1 > d2 * y1 && Overflow */        \
+                             std::numeric_limits<scalar_t>::min(), true,       \
+                             IS_POINTER), /* d1 * x1 > d2 * y1 && Overflow */  \
              std::make_tuple(                                                  \
                  C, std::numeric_limits<scalar_t>::max(),                      \
-                 std::numeric_limits<scalar_t>::max(), 0.01, 0.01,             \
-                 true), /* d1 * x1 <= d2 * y1 (i.e. abs_c <= abs_s) */         \
-             std::make_tuple(C, 2.1, 4.0, 1.5, 3.4, false),                    \
-             std::make_tuple(C, 2.1, 4.0, -1.5, 3.4, false),                   \
-             std::make_tuple(C, 2.1, -4.0, 1.5, 3.4, false),                   \
-             std::make_tuple(C, 2.1, -4.0, 1.5, -3.4, false),                  \
-             std::make_tuple(C, 2.1, -4.0, -1.5, -3.4,                         \
-                             false), /* d1 * x1 <= d2 * y1 (i.e. abs_c <=      \
-                                        abs_s) && rescaling */                 \
+                 std::numeric_limits<scalar_t>::max(), 0.01, 0.01, true,       \
+                 IS_POINTER), /* d1 * x1 <= d2 * y1 (i.e. abs_c <= abs_s) */   \
+             std::make_tuple(C, 2.1, 4.0, 1.5, 3.4, false, IS_POINTER),        \
+             std::make_tuple(C, 2.1, 4.0, -1.5, 3.4, false, IS_POINTER),       \
+             std::make_tuple(C, 2.1, -4.0, 1.5, 3.4, false, IS_POINTER),       \
+             std::make_tuple(C, 2.1, -4.0, 1.5, -3.4, false, IS_POINTER),      \
+             std::make_tuple(C, 2.1, -4.0, -1.5, -3.4, false,                  \
+                             IS_POINTER), /* d1 * x1 <= d2 * y1 (i.e. abs_c <= \
+                                 abs_s) && rescaling */                        \
              std::make_tuple(C, 2.1, scale_down_gen<scalar_t>(), 1.5, 3.4,     \
-                             false),                                           \
+                             false, IS_POINTER),                               \
              std::make_tuple(C, 2.1, scale_down_gen<scalar_t>(), 1.5,          \
-                             scale_down_gen<scalar_t>(), false),               \
+                             scale_down_gen<scalar_t>(), false, IS_POINTER),   \
              std::make_tuple(C, 2.1, scale_up_gen<scalar_t>(), 1.5,            \
-                             scale_down_gen<scalar_t>(), false),               \
+                             scale_down_gen<scalar_t>(), false, IS_POINTER),   \
              std::make_tuple(C, 2.1, scale_down_gen<scalar_t>(), 1.5,          \
-                             scale_up_gen<scalar_t>(),                         \
-                             false), /* d1 * x1 <= d2 * y1 (i.e. abs_c <=      \
-                                        abs_s) && Underflow */                 \
+                             scale_up_gen<scalar_t>(), false,                  \
+                             IS_POINTER), /* d1 * x1 <= d2 * y1 (i.e. abs_c <= \
+                                 abs_s) && Underflow */                        \
              std::make_tuple(C, std::numeric_limits<scalar_t>::min(),          \
                              std::numeric_limits<scalar_t>::min(), 0.01, 0.01, \
-                             true), /* d1 * x1 <= d2 * y1 (i.e. abs_c <=       \
-                                       abs_s) && Overflow */                   \
+                             true, IS_POINTER), /* d1 * x1 <= d2 * y1 (i.e.    \
+                                       abs_c <= abs_s) && Overflow */          \
              std::make_tuple(C, 0.01, 0.01,                                    \
                              std::numeric_limits<scalar_t>::max(),             \
-                             std::numeric_limits<scalar_t>::max(),             \
-                             true), /* Overflow all */                         \
+                             std::numeric_limits<scalar_t>::max(), true,       \
+                             IS_POINTER), /* Overflow all */                   \
              std::make_tuple(C, std::numeric_limits<scalar_t>::max(),          \
                              std::numeric_limits<scalar_t>::max(),             \
                              std::numeric_limits<scalar_t>::max(),             \
-                             std::numeric_limits<scalar_t>::max(),             \
-                             true), /* Underflow all */                        \
-             std::make_tuple(C, std::numeric_limits<scalar_t>::min(),          \
-                             std::numeric_limits<scalar_t>::min(),             \
-                             std::numeric_limits<scalar_t>::min(),             \
-                             std::numeric_limits<scalar_t>::min(),             \
-                             true), /* Numeric limits of one parameter */      \
-             std::make_tuple(C, 1.0, 1.0, 1.0,                                 \
-                             std::numeric_limits<scalar_t>::max(), false),     \
-             std::make_tuple(C, 1.0, 1.0,                                      \
-                             std::numeric_limits<scalar_t>::max(), 1.0,        \
-                             false),                                           \
-             std::make_tuple(C, 1.0, std::numeric_limits<scalar_t>::max(),     \
-                             1.0, 1.0, false),                                 \
+                             std::numeric_limits<scalar_t>::max(), true,       \
+                             IS_POINTER), /* Underflow all */                  \
              std::make_tuple(                                                  \
-                 C, std::numeric_limits<scalar_t>::max(), 1.0, 1.0, 1.0,       \
-                 false), /* Case that creates an infinite loop on cblas */     \
+                 C, std::numeric_limits<scalar_t>::min(),                      \
+                 std::numeric_limits<scalar_t>::min(),                         \
+                 std::numeric_limits<scalar_t>::min(),                         \
+                 std::numeric_limits<scalar_t>::min(), true,                   \
+                 IS_POINTER), /* Numeric limits of one parameter */            \
+             std::make_tuple(C, 1.0, 1.0, 1.0,                                 \
+                             std::numeric_limits<scalar_t>::max(), false,      \
+                             IS_POINTER),                                      \
+             std::make_tuple(C, 1.0, 1.0,                                      \
+                             std::numeric_limits<scalar_t>::max(), 1.0, false, \
+                             IS_POINTER),                                      \
+             std::make_tuple(C, 1.0, std::numeric_limits<scalar_t>::max(),     \
+                             1.0, 1.0, false, IS_POINTER),                     \
+             std::make_tuple(C, std::numeric_limits<scalar_t>::max(), 1.0,     \
+                             1.0, 1.0, false,                                  \
+                             IS_POINTER), /* Case that creates an infinite     \
+                                             loop on cblas */                  \
              std::make_tuple(C, std::numeric_limits<scalar_t>::min(), -2.2,    \
                              std::numeric_limits<scalar_t>::min(),             \
-                             std::numeric_limits<scalar_t>::min(),             \
-                             true), /* Case that triggers underflow detection  \
-                                       on abs_c <= abs_s && s >= 0 */          \
+                             std::numeric_limits<scalar_t>::min(), true,       \
+                             IS_POINTER), /* Case that triggers underflow      \
+                                 detection on abs_c <= abs_s && s >= 0 */      \
              std::make_tuple(C, 15.5, -2.2,                                    \
                              std::numeric_limits<scalar_t>::min(),             \
-                             std::numeric_limits<scalar_t>::min(),             \
-                             false), /* Test for previous errors */            \
+                             std::numeric_limits<scalar_t>::min(), false,      \
+                             IS_POINTER), /* Test for previous errors */       \
              std::make_tuple(C, 0.0516274, -0.197215, -0.270436, -0.157621,    \
-                             false))
+                             false, IS_POINTER))
 
 #ifdef SB_ENABLE_USM
-INSTANTIATE_ROTMG_TESTS(combi_usm, "usm");  // instantiate usm tests
+INSTANTIATE_ROTMG_TESTS(combi_usm, "usm", true);  // instantiate usm tests
+INSTANTIATE_ROTMG_TESTS(combi_usm_scalar, "usm",
+                        false);  // instantiate usm tests
 #endif
-INSTANTIATE_ROTMG_TESTS(combi_buffer, "buf");  // instantiate buffer tests
+INSTANTIATE_ROTMG_TESTS(combi_buffer, "buf", true);  // instantiate buffer tests
+INSTANTIATE_ROTMG_TESTS(combi_buffer_scalar, "buf",
+                        false);  // instantiate buffer tests
 
 template <class T>
 static std::string generate_name(
     const ::testing::TestParamInfo<combination_t<T>>& info) {
   std::string alloc;
   T d1, d2, x1, y1;
-  bool will_overflow;
-  BLAS_GENERATE_NAME(info.param, alloc, d1, d2, x1, y1, will_overflow);
+  bool will_overflow, is_pointer;
+  BLAS_GENERATE_NAME(info.param, alloc, d1, d2, x1, y1, will_overflow,
+                     is_pointer);
 }
 
 #ifdef SB_ENABLE_USM
 BLAS_REGISTER_TEST_ALL(Rotmg_Usm, combination_t, combi_usm, generate_name);
+BLAS_REGISTER_TEST_ALL(Rotmg_Usm_scalar, combination_t, combi_usm_scalar,
+                       generate_name);
 #endif
 BLAS_REGISTER_TEST_ALL(Rotmg_Buffer, combination_t, combi_buffer,
+                       generate_name);
+BLAS_REGISTER_TEST_ALL(Rotmg_Buffer_scalar, combination_t, combi_buffer_scalar,
                        generate_name);
 
 #undef INSTANTIATE_ROTMG_TESTS


### PR DESCRIPTION
To offer proper oneMKL support `rotmg` operator must support the possibility to have `y1` argument passed as scalar value.
This PR enables this possibility by adding a check on its type and handling both cases: pointer/buffer or scalar.
Moreover, due to a bug in OpenCL the copy for DEFAULT target, that it generally used on CPUs, must be explicitly synchronized if using USM.

