### PR TITLE
Refactor SPR/SPR2 index group_broadcast

### DIFF
--- a/src/operations/blas2/spr.hpp
+++ b/src/operations/blas2/spr.hpp
@@ -101,12 +101,12 @@ typename rhs_1_t::value_t Spr<Single, isUpper, lhs_t, rhs_1_t, rhs_2_t>::eval(
 
   index_t row = 0, col = 0;
 
-#if defined(INTEL_GPU) || defined(NVIDIA_GPU)
+#if (defined(INTEL_GPU) || defined(NVIDIA_GPU)) && not defined(__ADAPTIVECPP__)
   if (!id) {
 #endif
     Spr<Single, isUpper, lhs_t, rhs_1_t, rhs_2_t>::compute_row_col(
         global_idx, N_, row, col);
-#if defined(INTEL_GPU) || defined(NVIDIA_GPU)
+#if (defined(INTEL_GPU) || defined(NVIDIA_GPU)) && not defined(__ADAPTIVECPP__)
   }
   sycl::vec<index_t, 2> bcast_idxs{row, col};
   bcast_idxs = sycl::group_broadcast(ndItem.get_group(), bcast_idxs);
@@ -115,7 +115,7 @@ typename rhs_1_t::value_t Spr<Single, isUpper, lhs_t, rhs_1_t, rhs_2_t>::eval(
 #endif
 
   if (global_idx < lhs_size) {
-#if defined(INTEL_GPU) || defined(NVIDIA_GPU)
+#if (defined(INTEL_GPU) || defined(NVIDIA_GPU)) && not defined(__ADAPTIVECPP__)
     if constexpr (isUpper) {
       if (id) {
         row += id;

--- a/src/operations/blas2/spr.hpp
+++ b/src/operations/blas2/spr.hpp
@@ -101,12 +101,12 @@ typename rhs_1_t::value_t Spr<Single, isUpper, lhs_t, rhs_1_t, rhs_2_t>::eval(
 
   index_t row = 0, col = 0;
 
-#ifndef __ADAPTIVECPP__
+#if defined(INTEL_GPU) || defined(NVIDIA_GPU)
   if (!id) {
 #endif
     Spr<Single, isUpper, lhs_t, rhs_1_t, rhs_2_t>::compute_row_col(
         global_idx, N_, row, col);
-#ifndef __ADAPTIVECPP__
+#if defined(INTEL_GPU) || defined(NVIDIA_GPU)
   }
   sycl::vec<index_t, 2> bcast_idxs{row, col};
   bcast_idxs = sycl::group_broadcast(ndItem.get_group(), bcast_idxs);
@@ -115,7 +115,7 @@ typename rhs_1_t::value_t Spr<Single, isUpper, lhs_t, rhs_1_t, rhs_2_t>::eval(
 #endif
 
   if (global_idx < lhs_size) {
-#ifndef __ADAPTIVECPP__
+#if defined(INTEL_GPU) || defined(NVIDIA_GPU)
     if constexpr (isUpper) {
       if (id) {
         row += id;

--- a/src/operations/blas2/spr.hpp
+++ b/src/operations/blas2/spr.hpp
@@ -108,9 +108,10 @@ typename rhs_1_t::value_t Spr<Single, isUpper, lhs_t, rhs_1_t, rhs_2_t>::eval(
         global_idx, N_, row, col);
 #ifndef __ADAPTIVECPP__
   }
-
-  row = sycl::group_broadcast(ndItem.get_group(), row);
-  col = sycl::group_broadcast(ndItem.get_group(), col);
+  sycl::vec<index_t, 2> bcast_idxs{row, col};
+  bcast_idxs = sycl::group_broadcast(ndItem.get_group(), bcast_idxs);
+  row = bcast_idxs[0];
+  col = bcast_idxs[1];
 #endif
 
   if (global_idx < lhs_size) {


### PR DESCRIPTION
This patch substitutes the `group_broadcast` of two individual indexes with a single broadcast of a vector type.